### PR TITLE
Use contests data when player's collection api is disabled

### DIFF
--- a/src/lib/weight.ts
+++ b/src/lib/weight.ts
@@ -65,22 +65,42 @@ export function CalculateWeight(profiles: ProfileData[], highest?: HighestWeight
 }
 
 export function calcCollections(member: ProfileMember) {
-	if (!member.collection) return undefined;
+	if (!member.collection) {  // collection api off
+        const total = {};
+        
+        for (const crop in member.jacob.contests) {
+            const contests = member.jacob.contests[crop as keyof typeof member.jacob.contests];
+            total[crop] = contests.reduce((acc, el) => acc + el.collected, 0);
+        }
+        
+        let {
+            wheat: WHEAT,
+            potato: POTATO,
+            carrot: CARROT,
+            mushroom: MUSHROOM,
+            pumpkin: PUMPKIN,
+            melon: MELON,
+            sugarcane: CANE,
+            cactus: CACTUS,
+            netherwart: WART,
+            cocoa: COCOA
+        } = total;
+    } else {
+        let {
+            WHEAT,
+            POTATO_ITEM: POTATO,
+            CARROT_ITEM: CARROT,
+            MUSHROOM_COLLECTION: MUSHROOM,
+            PUMPKIN,
+            MELON,
+            SUGAR_CANE: CANE,
+            CACTUS,
+            NETHER_STALK: WART,
+        } = member.collection;
 
-	let {
-		WHEAT,
-		POTATO_ITEM: POTATO,
-		CARROT_ITEM: CARROT,
-		MUSHROOM_COLLECTION: MUSHROOM,
-		PUMPKIN,
-		MELON,
-		SUGAR_CANE: CANE,
-		CACTUS,
-		NETHER_STALK: WART,
-	} = member.collection;
-
-	let COCOA = member.collection['INK_SACK:3']; // Dumb cocoa
-
+        let COCOA = member.collection['INK_SACK:3']; // Dumb cocoa
+    }
+    
 	if (isNaN(WHEAT)) WHEAT = 0;
 	if (isNaN(POTATO)) POTATO = 0;
 	if (isNaN(CARROT)) CARROT = 0;


### PR DESCRIPTION
In this pr I made a small change in the calcCollections function in the case of disabled collections api, which will consider collections as summed up values from the Farming Contests in which the player has participated. This allows partial calculation for players who didn't enable api. If a player participated in a lot of contests, it will make the calculation much more accurate and closer to the actual value.
It would be good to add a message that will tell the user about this calculation, possibly in apistatus.svelte. I didn't want to touch any frontend templates, I'll leave up to the maintainers to decide on this pull request.
Thanks for reviewing my PR, I hope to see it added to the website