### PR TITLE
Small Changes

### DIFF
--- a/src/components/events/linebreaks.svelte
+++ b/src/components/events/linebreaks.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	export let text: string;
+
+	// Split by \n or \r\n
+	$: lines = text.split('\n');
+</script>
+
+{#each lines as line, i (line)}
+	{line}
+	{#if i !== lines.length - 1}
+		<br />
+	{/if}
+{/each}

--- a/src/components/leaderboards/entry.svelte
+++ b/src/components/leaderboards/entry.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { page } from '$app/stores';
 	import type { LeaderboardEntry } from '$lib/api/elite';
 
 	export let entry: LeaderboardEntry;
@@ -6,13 +7,16 @@
 	export let rank: number;
 	export let formatting: 'number' | 'decimal' = 'number';
 
-	const options: Intl.NumberFormatOptions = {
+	$: options = {
 		maximumFractionDigits: 1,
-	};
+	} as Intl.NumberFormatOptions;
 
 	$: {
 		if (formatting === 'decimal') {
 			options.minimumFractionDigits = 1;
+		} else if ($page.params.category === 'skyblockxp') {
+			options.minimumFractionDigits = 2;
+			options.maximumFractionDigits = 2;
 		}
 	}
 	$: ({ ign, amount, profile } = entry);

--- a/src/components/stats/playerinfo.svelte
+++ b/src/components/stats/playerinfo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { RankName } from '$lib/skyblock';
-	import { getRankDefaults } from '$lib/format';
+	import { GetRankName, GetRankDefaults } from '$lib/format';
 	import { page } from '$app/stores';
 
 	import Weight from '$comp/stats/player/weight.svelte';
@@ -25,11 +25,8 @@
 
 	$: profilesData = { ign: player?.displayname ?? '', profiles: profiles, selected: profileDetails[0] };
 
-	$: rankName =
-		player?.rank ??
-		(player?.monthlyPackageRank !== 'NONE' ? player?.monthlyPackageRank : player?.newPackageRank) ??
-		undefined;
-	$: rank = getRankDefaults(rankName as RankName);
+	$: rankName = GetRankName(player);
+	$: rank = GetRankDefaults(rankName as RankName);
 </script>
 
 <section class="flex justify-center w-full my-8">

--- a/src/lib/api/api.d.ts
+++ b/src/lib/api/api.d.ts
@@ -262,6 +262,32 @@ export interface paths {
       };
     };
   };
+  "/Admin/UpcomingContests": {
+    delete: {
+      responses: {
+        /** @description Success */
+        200: {
+          content: never;
+        };
+        /** @description Unauthorized */
+        401: {
+          content: {
+            "text/plain": string;
+            "application/json": string;
+            "text/json": string;
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          content: {
+            "text/plain": string;
+            "application/json": string;
+            "text/json": string;
+          };
+        };
+      };
+    };
+  };
   "/Event/create": {
     post: {
       requestBody?: {
@@ -1444,6 +1470,95 @@ export interface paths {
       };
     };
   };
+  "/Graph/Medals/now": {
+    get: {
+      parameters: {
+        query?: {
+          months?: number;
+        };
+      };
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            "text/plain": components["schemas"]["ContestBracketsDetailsDto"];
+            "application/json": components["schemas"]["ContestBracketsDetailsDto"];
+            "text/json": components["schemas"]["ContestBracketsDetailsDto"];
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          content: {
+            "text/plain": string;
+            "application/json": string;
+            "text/json": string;
+          };
+        };
+      };
+    };
+  };
+  "/Graph/Medals/{sbYear}/{sbMonth}": {
+    get: {
+      parameters: {
+        query?: {
+          months?: number;
+        };
+        path: {
+          sbYear: number;
+          sbMonth: number;
+        };
+      };
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            "text/plain": components["schemas"]["ContestBracketsDetailsDto"];
+            "application/json": components["schemas"]["ContestBracketsDetailsDto"];
+            "text/json": components["schemas"]["ContestBracketsDetailsDto"];
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          content: {
+            "text/plain": string;
+            "application/json": string;
+            "text/json": string;
+          };
+        };
+      };
+    };
+  };
+  "/Graph/Medals/{sbYear}": {
+    get: {
+      parameters: {
+        query?: {
+          years?: number;
+          months?: number;
+        };
+        path: {
+          sbYear: number;
+        };
+      };
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            "text/plain": components["schemas"]["ContestBracketsDetailsDto"][];
+            "application/json": components["schemas"]["ContestBracketsDetailsDto"][];
+            "text/json": components["schemas"]["ContestBracketsDetailsDto"][];
+          };
+        };
+        /** @description Bad Request */
+        400: {
+          content: {
+            "text/plain": string;
+            "application/json": string;
+            "text/json": string;
+          };
+        };
+      };
+    };
+  };
   "/Player/{playerUuidOrIgn}": {
     get: {
       parameters: {
@@ -2033,6 +2148,25 @@ export interface components {
      * @enum {integer}
      */
     ChannelType: 0 | 1 | 2 | 3 | 4 | 5 | 10 | 11 | 12 | 13 | 14 | 15;
+    ContestBracketsDetailsDto: {
+      start?: string;
+      end?: string;
+      brackets?: {
+        [key: string]: components["schemas"]["ContestBracketsDto"];
+      };
+    };
+    ContestBracketsDto: {
+      /** Format: int32 */
+      bronze?: number;
+      /** Format: int32 */
+      silver?: number;
+      /** Format: int32 */
+      gold?: number;
+      /** Format: int32 */
+      platinum?: number;
+      /** Format: int32 */
+      diamond?: number;
+    };
     /**
      * Format: int32
      * @enum {integer}
@@ -2423,6 +2557,7 @@ export interface components {
       timestamp?: number;
       /** Format: int32 */
       participants?: number;
+      brackets?: components["schemas"]["ContestBracketsDto"];
       participations?: components["schemas"]["StrippedContestParticipationDto"][];
     };
     JacobDataDto: {
@@ -2562,6 +2697,7 @@ export interface components {
       totalDailyRewards?: number;
       /** Format: int32 */
       totalRewards?: number;
+      prefix?: string | null;
       rank?: string | null;
       newPackageRank?: string | null;
       rankPlusColor?: string | null;
@@ -2715,8 +2851,8 @@ export interface components {
         [key: string]: number | null;
       }) | null;
       tempStatBuffs?: components["schemas"]["TempStatBuff"][] | null;
-      accessoryBagSettings?: Record<string, unknown> | null;
-      bestiary?: Record<string, unknown> | null;
+      accessoryBagSettings?: unknown;
+      bestiary?: unknown;
     };
     UserGuildDto: {
       id?: string;

--- a/src/lib/api/swagger.json
+++ b/src/lib/api/swagger.json
@@ -594,6 +594,58 @@
         }
       }
     },
+    "/Admin/UpcomingContests": {
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/Event/create": {
       "post": {
         "tags": [
@@ -3597,6 +3649,238 @@
         }
       }
     },
+    "/Graph/Medals/now": {
+      "get": {
+        "tags": [
+          "MedalGraphs"
+        ],
+        "parameters": [
+          {
+            "name": "months",
+            "in": "query",
+            "style": "form",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 2
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContestBracketsDetailsDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContestBracketsDetailsDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContestBracketsDetailsDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Graph/Medals/{sbYear}/{sbMonth}": {
+      "get": {
+        "tags": [
+          "MedalGraphs"
+        ],
+        "parameters": [
+          {
+            "name": "sbYear",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sbMonth",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "months",
+            "in": "query",
+            "style": "form",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 2
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContestBracketsDetailsDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContestBracketsDetailsDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContestBracketsDetailsDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Graph/Medals/{sbYear}": {
+      "get": {
+        "tags": [
+          "MedalGraphs"
+        ],
+        "parameters": [
+          {
+            "name": "sbYear",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "years",
+            "in": "query",
+            "style": "form",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "months",
+            "in": "query",
+            "style": "form",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 2
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContestBracketsDetailsDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContestBracketsDetailsDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContestBracketsDetailsDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/Player/{playerUuidOrIgn}": {
       "get": {
         "tags": [
@@ -5014,6 +5298,50 @@
         "type": "integer",
         "format": "int32"
       },
+      "ContestBracketsDetailsDto": {
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          },
+          "brackets": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ContestBracketsDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContestBracketsDto": {
+        "type": "object",
+        "properties": {
+          "bronze": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "silver": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "gold": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "platinum": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "diamond": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
       "ContestMedal": {
         "enum": [
           0,
@@ -6223,6 +6551,9 @@
             "type": "integer",
             "format": "int32"
           },
+          "brackets": {
+            "$ref": "#/components/schemas/ContestBracketsDto"
+          },
           "participations": {
             "type": "array",
             "items": {
@@ -6634,6 +6965,10 @@
           "totalRewards": {
             "type": "integer",
             "format": "int32"
+          },
+          "prefix": {
+            "type": "string",
+            "nullable": true
           },
           "rank": {
             "type": "string",

--- a/src/lib/constants/leaderboards.ts
+++ b/src/lib/constants/leaderboards.ts
@@ -21,8 +21,8 @@ export const LEADERBOARDS: Record<string, LeaderboardConfig> = {
 	},
 	skyblockxp: {
 		limit: 5_000,
-		title: 'Skyblock XP',
-		name: 'Skyblock XP',
+		title: 'Skyblock Level',
+		name: 'Skyblock Level',
 		type: LeaderboardType.Misc,
 	},
 	participations: {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,3 +1,4 @@
+import type { components } from './api/api';
 import { MINECRAFT_FORMATTING_STYLE, type FormattingCode } from './constants/colors';
 import { RANKS, RANK_PLUS_COLORS, SKYBLOCK_MONTHS } from './constants/data';
 import { LEVEL_XP, DEFAULT_SKILL_CAPS, RUNE_LEVELS, SOCIAL_XP } from './constants/levels';
@@ -165,7 +166,34 @@ export function appendOrdinalSuffix(i: number) {
 	return `${i}th`;
 }
 
-export function getRankDefaults(rank?: RankName) {
+export function GetRankName(player?: components['schemas']['PlayerDataDto'] | null) {
+	if (!player) return undefined;
+
+	if (player.prefix) {
+		// Example: §c[OWNER] -> OWNER
+		// Also removes color codes between brackets for PIG+++
+		const match = player.prefix.replace(/§\w/g, '').match(/\[(.+?)\]/);
+		if (match) {
+			return match[1];
+		}
+	}
+
+	if (player.rank && player.rank !== 'NORMAL') {
+		return player.rank;
+	}
+
+	if (player.monthlyPackageRank && player.monthlyPackageRank !== 'NONE') {
+		return player.monthlyPackageRank;
+	}
+
+	if (player.newPackageRank && player.newPackageRank !== 'NONE') {
+		return player.newPackageRank;
+	}
+
+	return undefined;
+}
+
+export function GetRankDefaults(rank?: RankName) {
 	if (!rank) return undefined;
 
 	return RANKS[rank];

--- a/src/routes/(auth)/event/[event=slug]/join/+page.svelte
+++ b/src/routes/(auth)/event/[event=slug]/join/+page.svelte
@@ -38,13 +38,8 @@
 			</p>
 			<p>
 				Collection gain is cross checked with your tool usage. If you gain collection progress without using a
-				tool, it will not count towards your progress. <span class="text-red-500"
-					>If you remove a tool from one of your inventories during the event, all collection gained from its
-					use will be wiped from your score.</span
-				>
-				It is safe to move tools between inventories (e.g. from your inventory to your ender chest) as long as you
-				do not remove them from your inventories (by placing them in a chest on your island, trading them to another
-				player, voiding it, etc). New tools can be added to your inventories at any time.
+				tool, it will not count towards your progress. This also means a Daedalus Axe won't count either, as
+				there's no way to differentiate it from minions.
 			</p>
 			<p class="text-red-500">
 				Tools that do not have a built in counter require the Cultivating enchantment or your progress with that
@@ -56,24 +51,22 @@
 			</p>
 
 			<Checkbox name="confirm" value="true" class="mt-8" required>
-				I confirm that I have read all of <a
-					href="https://hypixel.net/rules"
-					class="underline text-blue-500 mx-1"
-				>
-					Hypixel's Server Rules
-				</a> and that I agree to them.
+				<p>
+					I confirm that I have read all of <a
+						href="https://hypixel.net/rules"
+						class="underline text-blue-500"
+					>
+						Hypixel's Server Rules
+					</a> and that I agree to them.
+				</p>
 			</Checkbox>
 
 			<Checkbox name="confirm" value="true" required>
-				I confirm that I have read the event's rules and that I agree to them.
+				I confirm that I have read the event's rules and disclaimers and that I agree to them.
 			</Checkbox>
 
 			<Checkbox name="confirm" value="true" required>
 				I confirm that I have read the rules of the related Discord Server and that I agree to them.
-			</Checkbox>
-
-			<Checkbox name="confirm" value="true" required>
-				I understand that this website does not act as a middleman nor is responsible for distributing prizes.
 			</Checkbox>
 
 			<Checkbox name="confirm" value="true" required>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,7 +24,7 @@
 
 <main>
 	<h1 class="text-4xl text-center my-16">Welcome to Elite!</h1>
-	<p class="text-body-xl text-center mb-16">View stats of any skyblock player!</p>
+	<p class="text-body-xl text-center mb-16">View farming stats of any skyblock player!</p>
 
 	<div class="flex flex-col w-full items-center gap-8">
 		{#if data.eliteGuild}
@@ -32,14 +32,13 @@
 				<Serverbar guild={data.eliteGuild} />
 			</div>
 		{/if}
-		<div class="flex flex-col md:flex-row gap-8 justify-center items-center">
-			<div class="flex flex-col items-center gap-8">
-				<Card color="none" border={false}>
+		<div class="flex flex-col md:flex-row gap-4 justify-center items-center">
+			<div class="flex flex-col items-center gap-4">
+				<Card color="none" border={false} class="dark:bg-zinc-800">
 					<h1 class="mb-4 w-full text-xl font-semibold">Join The Discord</h1>
 					<p class="w-full mb-6">
-						Join an exclusive community of Elite Farmers! Full membership unlocked after reaching {PUBLIC_WEIGHT_REQ}
-						farming weight. Talk to the best of the best with thousands of fellow farmers! Also, join the support
-						server for suggestions, bug reports, and coding talk!
+						Full membership unlocked after reaching {(+PUBLIC_WEIGHT_REQ).toLocaleString()}
+						farming weight. Also, join the support server for suggestions, bug reports!
 					</p>
 					<div class="flex flex-col md:flex-row gap-2 justify-center">
 						<Button
@@ -49,7 +48,7 @@
 							target="_blank"
 							rel="noopener noreferrer nofollow"
 						>
-							Elite farmers
+							Elite Farmers
 							<ArrowUpRightFromSquareOutline class="ml-2" size="sm" />
 						</Button>
 						<Button
@@ -64,11 +63,32 @@
 						</Button>
 					</div>
 				</Card>
-				<Card color="none" border={false}>
+				<Card color="none" border={false} class="dark:bg-zinc-800">
+					<h1 class="mb-4 w-full text-xl font-semibold">Support Development!</h1>
+					<p class="w-full mb-6">
+						Donate on Ko-Fi to support the development of Elite! Also check Server Subscriptions on the
+						development server to unlock some perks!
+					</p>
+					<div class="flex justify-center">
+						<Button
+							href={PUBLIC_DONATION_URL}
+							class="w-fit font-semibold"
+							target="_blank"
+							color="green"
+							rel="noopener noreferrer nofollow"
+						>
+							Donate on Ko-Fi
+							<ArrowUpRightFromSquareOutline class="ml-2" size="sm" />
+						</Button>
+					</div>
+				</Card>
+			</div>
+			<div class="flex flex-col items-center gap-4">
+				<Card color="none" border={false} class="dark:bg-zinc-800">
 					<h1 class="mb-4 w-full text-xl font-semibold">Add To Discord</h1>
 					<p class="w-full mb-6">
-						Quickly access stats and leaderboards in Discord! Please note that the bot runs seperately from
-						the website for now, leaderboards and stats may be out of sync.
+						Quickly access stats and leaderboards in Discord! Try out commands like <strong>/weight</strong
+						>, <strong>/rates</strong>, and <strong>/leaderboard</strong>!
 					</p>
 					<div class="flex justify-center">
 						<Button
@@ -83,36 +103,27 @@
 						</Button>
 					</div>
 				</Card>
-			</div>
-			<div class="flex flex-col items-center">
-				<Card class="!p-0 overflow-hidden" size="sm">
-					{#if donationClicked}
-						<iframe
-							id="kofiframe"
-							src="{PUBLIC_DONATION_URL}/?hidefeed=true&widget=true&embed=true&preview=true"
-							style="border:none;width:100%;padding:4px;"
-							height="512"
-							title="kaeso"
-						/>
-					{:else}
-						<button on:click={() => (donationClicked = true)}>
-							<img src="images/SupportKaeso.webp" alt="Support The Website" /></button
+				<Card color="none" border={false} class="dark:bg-zinc-800">
+					<h1 class="mb-4 w-full text-xl font-semibold">Purchase Crop Stickers!</h1>
+					<p class="w-full mb-6">
+						Direcly support the art on Elite by purchasing crop stickers! All proceeds go to the artist, and
+						you get a cool sticker!
+					</p>
+					<div class="flex justify-center">
+						<Button
+							href="https://www.etsy.com/listing/1499421785/pixelated-crop-stickers"
+							class="w-fit font-semibold"
+							target="_blank"
+							color="green"
+							rel="noopener noreferrer nofollow"
 						>
-					{/if}
+							Open Lumini's Shop
+							<ArrowUpRightFromSquareOutline class="ml-2" size="sm" />
+						</Button>
+					</div>
 				</Card>
 			</div>
 		</div>
-		<a
-			class="lumini flex flex-row gap-8 w-1/2 hover:shadow-xl rounded-md"
-			href="https://www.etsy.com/listing/1499421785/pixelated-crop-stickers"
-			target="_blank"
-			rel="noopener noreferrer nofollow"
-		>
-			<h1 class="p-8 text-3xl font-semibold">
-				Art By Lumini
-				<span class="text-sm font-xl">Click Me To Check Out Their Shop!</span>
-			</h1>
-		</a>
 	</div>
 
 	<section class="flex justify-center mt-4 mb-10">
@@ -131,17 +142,3 @@
 		</div>
 	</section>
 </main>
-
-<style>
-	.lumini {
-		display: block;
-		background-image: url('/images/LuminiBanner.webp');
-		background-size: cover;
-		background-position: center;
-		height: fit-content;
-	}
-
-	.lumini h1 {
-		color: black;
-	}
-</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,8 +13,6 @@
 	export let data: PageData;
 
 	$: entries = data.lb as LeaderboardEntry[];
-
-	let donationClicked = false;
 </script>
 
 <Head

--- a/src/routes/contests/+page.svelte
+++ b/src/routes/contests/+page.svelte
@@ -211,6 +211,10 @@
 							>
 						</Button>
 					</form>
+					<a
+						href="/contests/{yearVal + 2}/{monthVal + 1}/{dayVal + 1}"
+						class="underline text-gray-500 text-sm leading-none">Jump to most recent contest</a
+					>
 				</div>
 			</div>
 		</Card>

--- a/src/routes/contests/[year=int]/[month=int]/+page.svelte
+++ b/src/routes/contests/[year=int]/[month=int]/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/stores';
 	import Head from '$comp/head.svelte';
 	import { PROPER_CROP_TO_IMG } from '$lib/constants/crops';
-	import { getSkyblockMonth } from '$lib/format';
+	import { getSkyblockMonth, getTimeStamp } from '$lib/format';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -20,7 +20,17 @@
 <main class="flex flex-col justify-center items-center px-2">
 	<div class="font-semibold text-center mt-16 mb-4 flex flex-col gap-4">
 		<h1 class="text-4xl">{getSkyblockMonth(month)}, Year {year}</h1>
-
+		<p>
+			{new Date(getTimeStamp(+year - 1, month - 1, 0) * 1000).toLocaleString(undefined, {
+				timeStyle: 'short',
+				dateStyle: 'medium',
+			}) +
+				' - ' +
+				new Date(getTimeStamp(+year - 1, month, 0) * 1000).toLocaleString(undefined, {
+					timeStyle: 'short',
+					dateStyle: 'medium',
+				})}
+		</p>
 		<div class="flex flex-col justify-center items-center gap-2 md:gap-4 my-4">
 			<div class="flex flex-row gap-4">
 				<a

--- a/src/routes/event/[event=slug]/+page.svelte
+++ b/src/routes/event/[event=slug]/+page.svelte
@@ -74,7 +74,7 @@
 	</div>
 
 	<div class="flex flex-col lg:flex-row gap-8 max-w-6xl">
-		<section class="flex flex-col gap-4 max-w-64 bg-gray-100 dark:bg-zinc-800 rounded-md p-8">
+		<section class="flex flex-1 flex-col gap-4 max-w-64 bg-gray-100 dark:bg-zinc-800 rounded-md p-8">
 			<h2 class="text-3xl">{event.name}</h2>
 			<div class="flex flex-col gap-4">
 				<div class="flex flex-row gap-2 font-semibold items-center text-lg">
@@ -115,7 +115,7 @@
 				</div>
 			</div>
 		</section>
-		<section class="flex flex-col gap-4 items-center bg-gray-100 dark:bg-zinc-800 rounded-md p-8">
+		<section class="flex flex-1 flex-col gap-4 items-center bg-gray-100 dark:bg-zinc-800 rounded-md p-8">
 			<div class="flex flex-row gap-8 items-center justify-center w-full">
 				<h2 class="text-2xl">Members</h2>
 				<div class="flex flex-row gap-2 font-semibold items-center z-10">

--- a/src/routes/event/[event=slug]/+page.svelte
+++ b/src/routes/event/[event=slug]/+page.svelte
@@ -7,6 +7,7 @@
 	import { getCountdown } from '$lib/format';
 	import { page } from '$app/stores';
 	import Eventmember from './eventmember.svelte';
+	import Linebreaks from '$comp/events/linebreaks.svelte';
 
 	export let data: PageData;
 
@@ -73,20 +74,37 @@
 	</div>
 
 	<div class="flex flex-col lg:flex-row gap-8 max-w-6xl">
-		<section class="flex flex-1 basis-1/3 flex-col gap-4 max-w-64 bg-gray-100 dark:bg-zinc-800 rounded-md p-8">
+		<section class="flex flex-col gap-4 max-w-64 bg-gray-100 dark:bg-zinc-800 rounded-md p-8">
 			<h2 class="text-3xl">{event.name}</h2>
 			<div class="flex flex-col gap-4">
-				<p>{event.description}</p>
+				<div class="flex flex-row gap-2 font-semibold items-center text-lg">
+					<span>{new Date(start).toLocaleDateString()}</span>
+					<span
+						>{new Date(start).toLocaleTimeString(undefined, {
+							hour: 'numeric',
+							minute: '2-digit',
+						})}</span
+					>
+					<span> - </span>
+					<span>{new Date(end).toLocaleDateString()}</span>
+					<span
+						>{new Date(end).toLocaleTimeString(undefined, {
+							hour: 'numeric',
+							minute: '2-digit',
+						})}</span
+					>
+				</div>
+				<p><Linebreaks text={event.description ?? ''} /></p>
 				<p><strong>Rules</strong></p>
 				{#if event.rules}
 					<p>
-						{event.rules}
+						<Linebreaks text={event.rules ?? ''} />
 					</p>
 				{/if}
 				<a href="#agreement" class="text-blue-500 underline">Event Agreement</a>
 				{#if event.prizeInfo}
 					<p><strong>Prizes</strong></p>
-					<p>{event.prizeInfo}</p>
+					<p><Linebreaks text={event.prizeInfo ?? ''} /></p>
 				{/if}
 				<div class="flex flex-row justify-center gap-2 mt-4">
 					<Button href="{$page.url.pathname}/join" color="blue">
@@ -97,7 +115,7 @@
 				</div>
 			</div>
 		</section>
-		<section class="flex flex-1 basis-1/3 flex-col gap-4 items-center bg-gray-100 dark:bg-zinc-800 rounded-md p-8">
+		<section class="flex flex-col gap-4 items-center bg-gray-100 dark:bg-zinc-800 rounded-md p-8">
 			<div class="flex flex-row gap-8 items-center justify-center w-full">
 				<h2 class="text-2xl">Members</h2>
 				<div class="flex flex-row gap-2 font-semibold items-center z-10">

--- a/src/routes/event/[event=slug]/leaderboard/+page.svelte
+++ b/src/routes/event/[event=slug]/leaderboard/+page.svelte
@@ -5,6 +5,7 @@
 	import { ArrowUpRightFromSquareOutline, UserGroupSolid } from 'flowbite-svelte-icons';
 	import Eventmember from '../eventmember.svelte';
 	import { page } from '$app/stores';
+	import Linebreaks from '$comp/events/linebreaks.svelte';
 
 	export let data: PageData;
 
@@ -24,7 +25,7 @@
 		class="flex flex-col gap-4 max-w-64 bg-gray-100 dark:bg-zinc-800 rounded-md p-8 mt-16 max-w-5xl w-full items-center"
 	>
 		<h2 class="text-2xl md:text-4xl text-center">{event.name}</h2>
-		<p class="md:text-lg text-center">{event.description}</p>
+		<p class="md:text-lg text-center"><Linebreaks text={event.description ?? ''} /></p>
 		<div class="flex flex-row justify-center gap-2 mt-4 max-w-2xl w-full items-center">
 			<Button href="/server/{guild.id}/join" color="blue" size="sm" class="flex-1">
 				<p class="mr-2">Join Discord</p>

--- a/src/routes/leaderboard/[category]/[[start=int]]/+page.server.ts
+++ b/src/routes/leaderboard/[category]/[[start=int]]/+page.server.ts
@@ -1,6 +1,6 @@
 import { GetCollectionLeaderboardSlice, GetLeaderboardSlice, GetSkillLeaderboardSlice } from '$lib/api/elite';
 import { error } from '@sveltejs/kit';
-import { LeaderboardType } from '$lib/constants/leaderboards';
+import { LEADERBOARDS, LeaderboardType } from '$lib/constants/leaderboards';
 
 import type { PageServerLoad } from './$types';
 export const load = (async ({ params, parent }) => {
@@ -39,9 +39,15 @@ export const load = (async ({ params, parent }) => {
 			throw error(500, "Leaderboard data couldn't be fetched");
 		}
 
+		const lbSettings = LEADERBOARDS[lb.id as keyof typeof LEADERBOARDS];
+
+		if (lbSettings) {
+			lb.title = lbSettings.title;
+		}
+
 		return {
 			lb,
-			formatting: type === LeaderboardType.Skill ? 'decimal' : ('number' as 'decimal' | 'number'),
+			formatting: (type === LeaderboardType.Skill ? 'decimal' : 'number') as 'decimal' | 'number',
 		};
 	} catch (e) {
 		throw error(500, "Leaderboard data couldn't be fetched. Please try again later.");

--- a/src/routes/leaderboard/[category]/[[start=int]]/+page.svelte
+++ b/src/routes/leaderboard/[category]/[[start=int]]/+page.svelte
@@ -14,16 +14,15 @@
 
 	$: firstHalf = entries.slice(0, Math.ceil(entries.length / 2)) as LeaderboardEntry[];
 	$: secondHalf = entries.slice(Math.ceil(entries.length / 2)) as LeaderboardEntry[];
-
 	$: formatting = data.formatting;
 
-	const options: Intl.NumberFormatOptions = {
-		maximumFractionDigits: 1,
-	};
-
 	$: {
-		if (formatting === 'decimal') {
-			options.minimumFractionDigits = 1;
+		if (data.lb.id === 'skyblockxp') {
+			entries = entries.map((entry) => ({
+				ign: entry.ign,
+				profile: entry.profile,
+				amount: (entry.amount ?? 0) / 100,
+			}));
 		}
 	}
 

--- a/src/routes/leaderboard/[category]/[player=id]-[profile]/+page.server.ts
+++ b/src/routes/leaderboard/[category]/[player=id]-[profile]/+page.server.ts
@@ -23,5 +23,7 @@ export const load = (async ({ params }) => {
 		throw error(404, "This player isn't on the leaderboard!");
 	}
 
-	throw redirect(302, `/leaderboard/${category}/${rank.rank}`);
+	const pageRank = Math.max(1, rank.rank - 10);
+
+	throw redirect(302, `/leaderboard/${category}/${pageRank}`);
 }) satisfies PageServerLoad;


### PR DESCRIPTION
A bunch of small changes

- Fix rank display - fixes #195
- Add timestamps to contests and events
- Jump to position - 10 for a player on the leaderboard
- Improve main page layout
- Format Skyblock level leaderboard as "123.45" instead of "12,345"
- Adds jump to most recent contest button to /contests page