### PR TITLE
Update `farming-weight` to `0.3.9`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"clsx": "^2.1.0",
 		"cmdk-sv": "^0.0.13",
 		"embla-carousel-svelte": "8.0.0-rc19",
-		"farming-weight": "^0.3.6",
+		"farming-weight": "^0.3.9",
 		"formsnap": "^0.4.4",
 		"lucide-svelte": "^0.314.0",
 		"mode-watcher": "^0.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: 8.0.0-rc19
     version: 8.0.0-rc19(svelte@4.2.12)
   farming-weight:
-    specifier: ^0.3.6
-    version: 0.3.6
+    specifier: ^0.3.9
+    version: 0.3.9
   formsnap:
     specifier: ^0.4.4
     version: 0.4.4(svelte@4.2.12)(sveltekit-superforms@1.13.4)(zod@3.22.4)
@@ -1893,8 +1893,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /farming-weight@0.3.6:
-    resolution: {integrity: sha512-3BZmZb+E4ACxoGuTv9NFd6t0qe4/kpO8tllYdoyzMLkOIWBEcY1802LcdAF3mu8gJd8XQMJRLoeVS2l/P7QoXg==}
+  /farming-weight@0.3.9:
+    resolution: {integrity: sha512-0qHmosVl3egZiX3eay6aVE/awKY1VjxCGFX9F7GtKCFYUbaARGs6s1PFByPTsOI+lQWa3GAnD9aMBT8APSmRww==}
     dev: false
 
   /fast-deep-equal@3.1.3:


### PR DESCRIPTION
- Fixes farming level not counting on Rancher's boots
- Adds peridot gem support when counting fortune