### PR TITLE
Allow dashed uuids in stats page url

### DIFF
--- a/src/components/footer/footer.svelte
+++ b/src/components/footer/footer.svelte
@@ -24,10 +24,11 @@
 		<div class="flex flex-1 basis-32 py-4 flex-col gap-2 items-start">
 			<h5 class="text-lg font-semibold">Community</h5>
 			<Separator />
+			<Button variant="link" class="p-0 h-8" href="/browse">Browse Servers</Button>
 			<Button variant="link" rel="nofollow noreferrer noopener" class="p-0 h-8" href={PUBLIC_COMMUNITY_INVITE}
 				>Elite Farmers Discord</Button
 			>
-			<Button variant="link" class="p-0 h-8" href="/browse">Browse Servers</Button>
+			<Button variant="link" class="p-0 h-8" href="/wiki">Elite Farmers Wiki</Button>
 			<Button variant="link" rel="nofollow noreferrer noopener" class="p-0 h-8" href="https://hypixel.net/forums"
 				>Hypixel Forums</Button
 			>

--- a/src/components/stats/contests/singlecontest.svelte
+++ b/src/components/stats/contests/singlecontest.svelte
@@ -41,7 +41,7 @@
 					timeStyle: 'short',
 					dateStyle: 'short',
 					timeZone: 'UTC',
-				})}
+				})} UTC
 			</span>
 			<span class="bg-gray-200 dark:bg-zinc-900 p-1 px-2 rounded-md whitespace-nowrap">
 				{getReadableSkyblockDate(timestamp)}

--- a/src/components/stats/minion.svelte
+++ b/src/components/stats/minion.svelte
@@ -33,17 +33,21 @@
 		<div class="bg-primary-foreground absolute tier-cover" />
 	</div>
 
-	<div class="text-lg text-center">Unlocked {name} Minion Tiers</div>
-	<div class="flex gap-1 justify-center items-center text-black dark:text-white">
-		{#each tiers as tier, i}
-			<div
-				class="block flex-1 px-1 text-center text-lg rounded-sm {tier === '1'
-					? 'bg-muted'
-					: 'bg-primary-foreground'}"
-			>
-				<p>{i + 1}</p>
-			</div>
-		{/each}
+	<div class="flex flex-col justify-center items-center max-w-lg">
+		<div class="text-lg text-center my-2 mx-4">Unlocked {name} Minion Tiers</div>
+		<div class="grid grid-cols-6 gap-1 justify-center items-center max-w-52">
+			{#each tiers as tier, i}
+				<div
+					class="flex flex-row px-1 justify-center text-lg rounded-sm {tier === '1'
+						? maxed
+							? 'bg-yellow-400 dark:bg-yellow-600'
+							: 'bg-green-400 dark:bg-green-600'
+						: 'bg-primary-foreground'}"
+				>
+					<p>{i + 1}</p>
+				</div>
+			{/each}
+		</div>
 	</div>
 </Popover.Mobile>
 

--- a/src/content/faq.ts
+++ b/src/content/faq.ts
@@ -15,10 +15,19 @@ export const FAQ: Faq[] = [
 	{
 		question: 'Why are there cheaters on the leaderboard?',
 		answer: `
-			Unfortunately, it's hard to identify cheaters. The only way to do so is to manually check every player's
-			farming habits and responsiveness in-game. This is a very time-consuming process, and isn't something
-			that is conclusive. Despite this, cheaters will be removed from the leaderboard if they are found and
-			reported with truly undeniable proof.
+			Unfortunately, it's hard to identify cheaters. This website does not work as an authority on who is
+			cheating and who is not. Some features are also intended to be a direct representation of in-game stats
+			as well, like Jacob contest placements. It's possible a blacklisting system will be implemented in the 
+			future for the main leaderboards, but for now, we have no intention or system in place to flag and remove
+			cheaters. If you suspect someone is cheating, please report them to Hypixel using the /wdr command in-game. 
+		`,
+	},
+	{
+		question: 'How do I get on a leaderboard?',
+		answer: `
+			Once your stats qualify for a leaderboard placement, you will be automatically added to it! New entries to
+			leaderboards are only calculated every 30 minutes, so you may not see yourself on the leaderboard immediately 
+			after you qualify.
 		`,
 	},
 	{

--- a/src/routes/@[id=id]/+layout.server.ts
+++ b/src/routes/@[id=id]/+layout.server.ts
@@ -30,7 +30,7 @@ export const load: LayoutServerLoad = async (event) => {
 
 	const { id, profile } = params;
 
-	const { data: account } = await GetAccount(id).catch(() => ({ data: undefined }));
+	const { data: account } = await GetAccount(id.replaceAll('-', '')).catch(() => ({ data: undefined }));
 
 	if (!account?.id || !account.name) {
 		throw error(404, 'Player not found');
@@ -43,8 +43,11 @@ export const load: LayoutServerLoad = async (event) => {
 	}
 
 	const selectedProfile = profile
-		? profiles.find((p) => p.profileId === profile || p.profileName?.toUpperCase() === profile.toUpperCase()) ??
-		  profiles[0]
+		? profiles.find(
+				(p) =>
+					p.profileId === profile.replaceAll('-', '') ||
+					p.profileName?.toUpperCase() === profile.toUpperCase()
+		  ) ?? profiles[0]
 		: profiles.find((p) => p.selected) ?? profiles[0];
 
 	if (!selectedProfile.profileId || !selectedProfile.profileName) {

--- a/src/routes/[catch]/+server.ts
+++ b/src/routes/[catch]/+server.ts
@@ -17,6 +17,7 @@ const urls: Partial<Record<string, string>> = {
 	privacy: PUBLIC_PRIVACY_URL,
 	oss: '/oss.txt',
 	store: '/shop',
+	wiki: 'https://wiki.elitebot.dev/',
 };
 
 export const GET = (async ({ params }) => {

--- a/src/routes/info/+page.svelte
+++ b/src/routes/info/+page.svelte
@@ -21,11 +21,12 @@
 		<article class="max-w-4xl w-full px-4">
 			<h2 class="text-2xl my-8">What is Farming Weight?</h2>
 			<p class="text-lg my-4">
-				Farming Weight is a number that essentially represents how long and how efficient a player has been
-				farming. It is calculated by using a different formula for each crop that a player has farmed, and then
-				adding them all together. Farming XP is not a factor in this calculation outside of one time bonus
-				weight amounts. This is to ensure that players who farm using rabbit or who farm higher XP crops don't
-				have an unfair advantage over players who farm using other methods.
+				Farming weight is a number that essentially represents how long and how efficient a player has been
+				farming. The basic idea is to balance the collection between crops, so one player's crop collection can
+				be compared with another players collection of a different crop. The focus on crop collections means
+				that Farming XP is not a factor in this calculation outside of one time bonus weight amounts. This is to
+				ensure that players who farm for XP crops don't have an unfair advantage in farming weight gain over
+				players who farm using other methods.
 			</p>
 		</article>
 		<article class="max-w-4xl w-full px-4">
@@ -53,10 +54,12 @@
 		<h1 class="text-center text-3xl mt-16 mb-8">Pest Weight Adjustment</h1>
 		<p class="text-lg my-4 max-w-4xl w-full px-4">
 			The introduction of pests to the garden has brought a new (and unreliable) source of crop collection into
-			the game which needs to be accounted for in the Farming Weight calculation. Due to the different spawn rates
-			and drop amounts per player when they kill pests, the weight calculation now subtracts a certain amount of
-			crop collections before applying the formula. Your collection numbers are still accurate, this subtraction
-			is just done during the calculation.
+			the game which needs to be accounted for in farming weight. If pest drops were balanced in-game there would
+			be no issue with them counting towards farming weight, but they aren't. To counteract this unbalance, the
+			weight calculation subtracts an averaged amount of crop collections per pest kill before applying the
+			formula. The subtracted amount is also in brackets as shown below to compensate for fortune differences.
+			Your collection numbers on the site are still accurate, this subtraction is just done internally during the
+			farming weight calculation.
 		</p>
 		<article class="max-w-4xl w-full px-4">
 			<h2 class="text-2xl my-8">Pest Brackets</h2>


### PR DESCRIPTION
Some small changes:
- Allow dashed uuids in stats page url (ex: https://elitebot.dev/@7da0c475-81dc-42b4-9621-18f8049147b7)
- Clarify some things on info page
- Add Elite Farmers wiki link to footer
- Improve unlocked minion tiers popup
- Add UTC timezone label to contest records