### PR TITLE
Fix more fortune display issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"d3-time-format": "^4.1.0",
 		"date-fns": "^3.6.0",
 		"embla-carousel-svelte": "8.0.0-rc19",
-		"farming-weight": "^0.6.1",
+		"farming-weight": "^0.6.3",
 		"formsnap": "^0.4.4",
 		"layercake": "^8.3.4",
 		"layerchart": "^0.44.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ dependencies:
     specifier: 8.0.0-rc19
     version: 8.0.0-rc19(svelte@4.2.15)
   farming-weight:
-    specifier: ^0.6.1
-    version: 0.6.1
+    specifier: ^0.6.3
+    version: 0.6.3
   formsnap:
     specifier: ^0.4.4
     version: 0.4.4(svelte@4.2.15)(sveltekit-superforms@1.13.4)(zod@3.23.4)
@@ -2346,8 +2346,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /farming-weight@0.6.1:
-    resolution: {integrity: sha512-tQzEBxbfB9ZTE+f0rUeNn9yacjbmjHyM/yXu7mvGuPgj6snSH/bqFd68EiBHL3C4luRcOgnv/1rVrY7F8iq9AQ==}
+  /farming-weight@0.6.3:
+    resolution: {integrity: sha512-PgyfyV5OceXustDmBKlxBKgTpfno305OTh51U1/4dL9dQH9SoribLuSwCF3nYSiXN8SCL2pmuTyAapnm1FREhw==}
     dev: false
 
   /fast-deep-equal@3.1.3:

--- a/src/components/items/tools/farmingtools.svelte
+++ b/src/components/items/tools/farmingtools.svelte
@@ -2,17 +2,28 @@
 	import type { components } from '$lib/api/api';
 	import { Button } from '$ui/button';
 	import Farmingtool from '$comp/items/tools/farmingtool.svelte';
-	import { FarmingTool as FT, getCropMilestoneLevels, type EliteItemDto } from 'farming-weight';
+	import { FarmingTool as FT, getCropMilestoneLevels, type EliteItemDto, FarmingPet, Stat } from 'farming-weight';
 
 	export let tools: components['schemas']['ItemDto'][];
 	export let garden: components['schemas']['GardenDto'] | undefined = undefined;
+	export let pets: components['schemas']['PetDto'][] = [];
 	export let shown = 10;
 
 	let currentShown = shown;
 
-	$: actualTools = FT.fromArray(tools as EliteItemDto[], {
+	$: options = {
 		milestones: getCropMilestoneLevels(garden?.crops ?? {}),
-	});
+		// Use the pet with the highest chimera farming fortune for fortune displayed on daedalus axe
+		selectedPet: FarmingPet.fromArray(pets)
+			.sort(
+				(a, b) =>
+					(b.getChimeraAffectedStats(1)?.[Stat.FarmingFortune] ?? 0) -
+					(a.getChimeraAffectedStats(1)?.[Stat.FarmingFortune] ?? 0)
+			)
+			.at(0),
+	};
+
+	$: actualTools = FT.fromArray(tools as EliteItemDto[], options);
 </script>
 
 {#if actualTools.length !== 0}

--- a/src/components/stats/contests/cropselector.svelte
+++ b/src/components/stats/contests/cropselector.svelte
@@ -4,6 +4,8 @@
 	const selectedCrops = getSelectedCrops();
 
 	export let radio = false;
+	export let href = '';
+	export let id = '';
 
 	function click(crop: string) {
 		if (radio) {
@@ -16,7 +18,12 @@
 	$: crops = Object.entries(PROPER_CROP_TO_IMG).sort(([a], [b]) => a.localeCompare(b));
 </script>
 
-<div class="flex flex-wrap items-center justify-center p-4 gap-2">
+<svelte:element
+	this={href ? 'a' : 'div'}
+	{href}
+	id={id ? id : undefined}
+	class="flex flex-wrap items-center justify-center p-4 gap-2 scroll-mt-32"
+>
 	{#each crops as [crop, src] (crop)}
 		<button
 			class="flex flex-row items-center justify-center gap-2 p-2 rounded-md hover:bg-muted {$selectedCrops[crop]
@@ -27,4 +34,4 @@
 			<img {src} alt={crop[0]} class="w-12 h-12 pixelated" />
 		</button>
 	{/each}
-</div>
+</svelte:element>

--- a/src/routes/@[id=id]/[[profile]]/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/+page.svelte
@@ -93,6 +93,7 @@
 				<Farmingtools
 					garden={member.garden}
 					tools={member.farmingWeight?.inventory?.tools ?? []}
+					pets={member.pets ?? []}
 					shown={10 - (member.events?.length ?? 0)}
 				/>
 			</div>

--- a/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
@@ -234,17 +234,17 @@
 				<div class="flex flex-col items-center justify-center gap-1 m-2">
 					<div class="flex flex-row gap-2 items-center min-h-10">
 						<p class="text-lg text-center leading-none">Temporary Fortune</p>
-						{#if $ratesData.useTemp}
-							<FortuneBreakdown total={$player.tempFortune} breakdown={$player.tempFortuneBreakdown} />
-						{/if}
+						<FortuneBreakdown total={$player.tempFortune} breakdown={$player.tempFortuneBreakdown} />
 					</div>
 					<div class="flex flex-row items-center justify-center gap-2">
 						<p class="text-md leading-none mb-1">Enabled</p>
 						<Switch bind:checked={$ratesData.useTemp} />
 					</div>
 				</div>
-				<div class="flex flex-col md:flex-row md:flex-wrap items-center md:items-start justify-center">
-					<div class="flex flex-col items-start gap-1 md:basis-48 m-2">
+				<div
+					class="flex flex-col md:flex-row flex-wrap items-start md:items-start justify-start md:justify-center"
+				>
+					<div class="flex flex-col items-start gap-1 w-full md:basis-48 m-2">
 						<p class="text-md leading-none">{TEMPORARY_FORTUNE.pestTurnIn.name} (40 Pests)</p>
 						<div class="flex flex-row items-center justify-center gap-2">
 							<Switch
@@ -252,60 +252,67 @@
 								onCheckedChange={(check) => {
 									$ratesData.temp.pestTurnIn = check ? 200 : 0;
 								}}
+								disabled={!$ratesData.useTemp}
 							/>
-							<FortuneBreakdown total={200} bind:enabled={pestTurnInChecked} />
+							<FortuneBreakdown total={200} enabled={pestTurnInChecked && $ratesData.useTemp} />
 						</div>
 					</div>
-					<div class="flex flex-col items-start gap-1 md:basis-48 m-2">
+					<div class="flex flex-col items-start gap-1 w-full md:basis-48 m-2">
 						<p class="text-md leading-none">{TEMPORARY_FORTUNE.centuryCake.name}</p>
 						<div class="flex flex-row items-center justify-center gap-2">
-							<Switch bind:checked={$ratesData.temp.centuryCake} />
-							<FortuneBreakdown total={5} bind:enabled={$ratesData.temp.centuryCake} />
+							<Switch bind:checked={$ratesData.temp.centuryCake} disabled={!$ratesData.useTemp} />
+							<FortuneBreakdown total={5} enabled={$ratesData.temp.centuryCake && $ratesData.useTemp} />
 						</div>
 					</div>
-					<div class="flex flex-col items-start gap-1 md:basis-48 m-2">
+					<div class="flex flex-col items-start gap-1 w-full md:basis-48 m-2">
 						<p class="text-md leading-none">{TEMPORARY_FORTUNE.flourSpray.name}</p>
 						<div class="flex flex-row items-center justify-center gap-2">
-							<Switch bind:checked={$ratesData.temp.flourSpray} />
-							<FortuneBreakdown total={20} bind:enabled={$ratesData.temp.flourSpray} />
+							<Switch bind:checked={$ratesData.temp.flourSpray} disabled={!$ratesData.useTemp} />
+							<FortuneBreakdown total={20} enabled={$ratesData.temp.flourSpray && $ratesData.useTemp} />
 						</div>
 					</div>
-					<div class="flex flex-col items-start gap-1 md:basis-48 m-2">
+					<div class="flex flex-col items-start gap-1 w-full md:basis-48 m-2">
 						<p class="text-md leading-none">{TEMPORARY_FORTUNE.harvestPotion.name}</p>
 						<div class="flex flex-row items-center justify-center gap-2">
-							<Switch bind:checked={$ratesData.temp.harvestPotion} />
-							<FortuneBreakdown total={50} bind:enabled={$ratesData.temp.harvestPotion} />
+							<Switch bind:checked={$ratesData.temp.harvestPotion} disabled={!$ratesData.useTemp} />
+							<FortuneBreakdown
+								total={50}
+								enabled={$ratesData.temp.harvestPotion && $ratesData.useTemp}
+							/>
 						</div>
 					</div>
-					<div class="flex flex-col items-start gap-1 md:basis-48 m-2">
+					<div class="flex flex-col items-start gap-1 w-full md:basis-48 m-2">
 						<p class="text-md leading-none">{TEMPORARY_FORTUNE.magic8Ball.name}</p>
 						<div class="flex flex-row items-center justify-center gap-2">
-							<Switch bind:checked={$ratesData.temp.magic8Ball} />
-							<FortuneBreakdown total={25} bind:enabled={$ratesData.temp.magic8Ball} />
+							<Switch bind:checked={$ratesData.temp.magic8Ball} disabled={!$ratesData.useTemp} />
+							<FortuneBreakdown total={25} enabled={$ratesData.temp.magic8Ball && $ratesData.useTemp} />
 						</div>
 					</div>
-					<div class="flex flex-col items-start gap-1 md:basis-48 m-2">
+					<div class="flex flex-col items-start gap-1 w-full md:basis-48 m-2">
 						<p class="text-md leading-none">{TEMPORARY_FORTUNE.springFilter.name}</p>
 						<div class="flex flex-row items-center justify-center gap-2">
-							<Switch bind:checked={$ratesData.temp.springFilter} />
-							<FortuneBreakdown total={25} bind:enabled={$ratesData.temp.springFilter} />
+							<Switch bind:checked={$ratesData.temp.springFilter} disabled={!$ratesData.useTemp} />
+							<FortuneBreakdown total={25} enabled={$ratesData.temp.springFilter && $ratesData.useTemp} />
 						</div>
 					</div>
-					<div class="flex flex-col items-start gap-1 md:basis-48 m-2">
+					<div class="flex flex-col items-start gap-1 w-full md:basis-48 m-2">
 						<p class="text-md leading-none">{TEMPORARY_FORTUNE.anitaContest.name}</p>
 						<div class="flex flex-row items-center justify-center gap-2">
-							<Switch bind:checked={$ratesData.temp.anitaContest} />
-							<FortuneBreakdown total={25} bind:enabled={$ratesData.temp.anitaContest} />
+							<Switch bind:checked={$ratesData.temp.anitaContest} disabled={!$ratesData.useTemp} />
+							<FortuneBreakdown total={25} enabled={$ratesData.temp.anitaContest && $ratesData.useTemp} />
 						</div>
 					</div>
-					<div class="flex flex-col items-start gap-1 md:basis-48 m-2">
+					<div class="flex flex-col items-start gap-1 w-full md:basis-48 m-2">
 						<p class="text-md leading-none">{TEMPORARY_FORTUNE.chocolateTruffle.name}</p>
 						<div class="flex flex-row items-center justify-center gap-2">
-							<Switch bind:checked={$ratesData.temp.chocolateTruffle} />
-							<FortuneBreakdown total={30} bind:enabled={$ratesData.temp.chocolateTruffle} />
+							<Switch bind:checked={$ratesData.temp.chocolateTruffle} disabled={!$ratesData.useTemp} />
+							<FortuneBreakdown
+								total={30}
+								enabled={$ratesData.temp.chocolateTruffle && $ratesData.useTemp}
+							/>
 						</div>
 					</div>
-					<div class="flex flex-col items-start gap-1 md:basis-48 m-2">
+					<div class="flex flex-col items-start gap-1 w-full md:basis-48 m-2">
 						<p class="text-md leading-none mb-1">Zorro's Cape Mode</p>
 						<div class="flex flex-row items-center justify-center gap-2">
 							<Select.Simple
@@ -502,13 +509,13 @@
 		</section>
 	</div>
 
-	<Cropselector radio={true} />
+	<Cropselector radio={true} href="#fortune" id="fortune" />
 
 	<div class="flex flex-col md:flex-row gap-4 max-w-6xl w-full justify-center">
 		<section class="flex-1 flex flex-col items-center w-full gap-4 p-4 rounded-md bg-primary-foreground">
 			<div class="flex flex-row gap-1 items-center justify-center w-full">
 				<div class="flex-1 flex flex-row justify-end">
-					<JumpLink id="fortune" />
+					<JumpLink id="fortune" self={false} />
 				</div>
 				<h2 class="text-2xl mb-1">Farming Fortune</h2>
 				<div class="flex-1" />


### PR DESCRIPTION
- Make second crop selector into the `#fortune` anchor, which fixes selecting a crop on mobile shifting the whole screen since the top expands.
- Update `farming-weight` package
  - Decreased bundle size
  - Fixes community center upgrade falsely being 50
  - Hopefully fixes lotus gear being detected as Common
- Fixes daedalus axes showing 0 fortune by loading in pets