### PR TITLE
Fix: Incorrect maxed fortune breakdown color

### DIFF
--- a/src/components/items/tools/fortune-breakdown.svelte
+++ b/src/components/items/tools/fortune-breakdown.svelte
@@ -29,8 +29,8 @@
 
 	let background = $derived(
 		enabled
-			? `bg-green-400 dark:bg-green-700 ${maxed ? 'bg-yellow-400 dark:bg-yellow-700' : ''}`
-			: `bg-green-400/40 dark:bg-green-700/40 ${maxed ? 'bg-yellow-400/40 dark:bg-yellow-700/40' : ''}`
+			? `bg-green-400 dark:bg-green-600 ${maxed ? 'bg-yellow-400 dark:bg-yellow-600' : ''}`
+			: `bg-green-400/40 dark:bg-green-600/40 ${maxed ? 'bg-yellow-400/40 dark:bg-yellow-600/40' : ''}`
 	);
 </script>
 

--- a/src/components/items/tools/fortune-breakdown.svelte
+++ b/src/components/items/tools/fortune-breakdown.svelte
@@ -29,8 +29,8 @@
 
 	let background = $derived(
 		enabled
-			? `bg-green-400 dark:bg-green-600 ${maxed ? 'bg-yellow-400 dark:bg-yellow-600' : ''}`
-			: `bg-green-400/40 dark:bg-green-600/40 ${maxed ? 'bg-yellow-400/40 dark:bg-yellow-600/40' : ''}`
+			? `bg-green-400 dark:bg-green-700 ${maxed ? 'bg-yellow-400 dark:bg-yellow-600' : ''}`
+			: `bg-green-400/40 dark:bg-green-700/40 ${maxed ? 'bg-yellow-400/40 dark:bg-yellow-600/40' : ''}`
 	);
 </script>
 


### PR DESCRIPTION
Resolves: https://discord.com/channels/1103875528479494275/1314488643150155776
Fixes the incorrect color being used for maxed fortune-breakdown component (currently only used in pb score ff tag).