### PR TITLE
Add new jacob crop stats

### DIFF
--- a/src/components/rates/pet-selector.svelte
+++ b/src/components/rates/pet-selector.svelte
@@ -18,7 +18,6 @@
 	let { selected = $bindable(undefined), player, onChange = undefined }: Props = $props();
 
 	let show = $state(2);
-	let fortune = $state($player.selectedPet?.breakdown);
 
 	selected = $player.selectedPet;
 
@@ -57,7 +56,6 @@
 		$player.selectPet(pet);
 		player.refresh();
 
-		fortune = pet.breakdown;
 		selected = pet;
 	}
 </script>
@@ -65,7 +63,7 @@
 <div class="flex w-full items-center justify-between pt-2">
 	<p class="text-lg font-semibold">Farming Pet</p>
 	{#if $player.selectedPet}
-		<FortuneBreakdown breakdown={fortune} />
+		<FortuneBreakdown breakdown={$player.selectedPet.breakdown} />
 	{:else}
 		<FortuneBreakdown total={0} />
 	{/if}

--- a/src/components/stats/breakdown.svelte
+++ b/src/components/stats/breakdown.svelte
@@ -35,11 +35,14 @@
 	});
 </script>
 
-<section class="flex w-full justify-center py-4 align-middle" aria-labelledby="Breakdown">
-	<div class="mx-2 w-full max-w-4xl rounded-lg bg-primary-foreground p-4">
-		<h1 id="Breakdown" class="pt-2 text-center text-3xl">Weight Breakdown - {total.toLocaleString()}</h1>
-		<div class="block justify-evenly py-4 md:flex">
-			<div class="w-full md:w-1/3">
+<section class="flex w-full flex-1 justify-center py-4 align-middle" aria-labelledby="Breakdown">
+	<div class="w-full max-w-4xl rounded-lg bg-primary-foreground">
+		<h2 id="Breakdown" class="mt-6 text-center">
+			<span class="mx-2 text-3xl font-semibold">{total.toLocaleString()}</span>
+			<span class="text-lg">Farming Weight</span>
+		</h2>
+		<div class="flex flex-col justify-evenly gap-4 px-4 pb-4 md:flex-row">
+			<div class="flex-1">
 				<h3 class="py-2 text-2xl font-semibold">
 					Crops
 					<span class="pl-2 text-lg">({(total - bonus).toLocaleString()})</span>
@@ -51,7 +54,7 @@
 					</div>
 				{/each}
 			</div>
-			<div class="w-full md:w-1/3">
+			<div class="flex-1">
 				<h3 class="py-2 text-2xl font-semibold">
 					Bonus<span class="pl-2 text-lg">({bonus.toLocaleString()})</span>
 				</h3>

--- a/src/components/stats/contests/crop-selector.svelte
+++ b/src/components/stats/contests/crop-selector.svelte
@@ -12,7 +12,14 @@
 
 	let { radio = false, href = '', id = '' }: Props = $props();
 
-	function click(crop: string) {
+	let scrollContainer = $state<HTMLElement | null>(null);
+
+	function click(
+		e: MouseEvent & {
+			currentTarget: EventTarget & HTMLButtonElement;
+		},
+		crop: string
+	) {
 		if (radio) {
 			selectedCrops.set({ ...DEFAULT_SELECTED_CROPS, [crop]: true });
 		} else {
@@ -21,19 +28,47 @@
 	}
 
 	let crops = $derived(Object.entries(PROPER_CROP_TO_IMG).sort(([a], [b]) => a.localeCompare(b)));
+
+	selectedCrops.subscribe((crops) => {
+		if (!radio || !scrollContainer) return;
+		const selected = Object.entries(crops)
+			.filter(([, selected]) => selected)
+			.map(([crop]) => crop);
+		for (const crop of selected) {
+			const button = scrollContainer?.querySelector(`button[data-crop="${crop}"]`) as HTMLButtonElement | null;
+			if (!button) continue;
+
+			const left =
+				button.offsetLeft +
+				button.getBoundingClientRect().width / 2 -
+				scrollContainer.getBoundingClientRect().width / 2;
+
+			scrollContainer?.scrollTo({ left, behavior: 'smooth' });
+		}
+	});
 </script>
 
-<svelte:element this={href ? 'a' : 'div'} {href} id={id ? id : undefined} class="max-w-full scroll-mt-32">
-	<ScrollArea orientation="horizontal" class="w-3xl overflow-hidden whitespace-nowrap rounded-md">
-		<div class="flex flex-row items-center justify-center gap-2 p-3">
+<svelte:element
+	this={href ? 'a' : 'div'}
+	{href}
+	id={id ? id : undefined}
+	class="max-w-full scroll-mt-32 overflow-hidden"
+>
+	<ScrollArea
+		bind:viewRef={scrollContainer}
+		orientation="horizontal"
+		class="overflow-x-auto whitespace-nowrap rounded-md"
+	>
+		<div class="flex min-w-max items-center justify-center gap-2 py-3">
 			{#each crops as [crop, src] (crop)}
 				<button
+					data-crop={crop}
 					class="flex aspect-square w-16 flex-row items-center justify-center gap-2 rounded-md p-2 hover:bg-muted {$selectedCrops[
 						crop
 					]
 						? 'bg-primary/15'
 						: ''}"
-					onclick={() => click(crop)}
+					onclick={(e) => click(e, crop)}
 				>
 					<img {src} alt={crop[0]} class="pixelated aspect-square h-12" />
 				</button>

--- a/src/components/stats/contests/crop-selector.svelte
+++ b/src/components/stats/contests/crop-selector.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <svelte:element this={href ? 'a' : 'div'} {href} id={id ? id : undefined} class="max-w-full scroll-mt-32">
-	<ScrollArea orientation="horizontal" class="w-3xl overflow-hidden whitespace-nowrap rounded-md border">
+	<ScrollArea orientation="horizontal" class="w-3xl overflow-hidden whitespace-nowrap rounded-md">
 		<div class="flex flex-row items-center justify-center gap-2 p-3">
 			{#each crops as [crop, src] (crop)}
 				<button

--- a/src/components/stats/contests/cropselector.svelte
+++ b/src/components/stats/contests/cropselector.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { ScrollArea } from '$ui/scroll-area';
 	import { PROPER_CROP_TO_IMG } from '$lib/constants/crops';
 	import { DEFAULT_SELECTED_CROPS, getSelectedCrops } from '$lib/stores/selectedCrops';
 	const selectedCrops = getSelectedCrops();
@@ -22,20 +23,21 @@
 	let crops = $derived(Object.entries(PROPER_CROP_TO_IMG).sort(([a], [b]) => a.localeCompare(b)));
 </script>
 
-<svelte:element
-	this={href ? 'a' : 'div'}
-	{href}
-	id={id ? id : undefined}
-	class="flex scroll-mt-32 flex-wrap items-center justify-center gap-2 p-4"
->
-	{#each crops as [crop, src] (crop)}
-		<button
-			class="flex flex-row items-center justify-center gap-2 rounded-md p-2 hover:bg-muted {$selectedCrops[crop]
-				? 'bg-primary/15'
-				: ''}"
-			onclick={() => click(crop)}
-		>
-			<img {src} alt={crop[0]} class="pixelated h-12 w-12" />
-		</button>
-	{/each}
+<svelte:element this={href ? 'a' : 'div'} {href} id={id ? id : undefined} class="max-w-full scroll-mt-32">
+	<ScrollArea orientation="horizontal" class="w-3xl overflow-hidden whitespace-nowrap rounded-md border">
+		<div class="flex flex-row items-center justify-center gap-2 p-3">
+			{#each crops as [crop, src] (crop)}
+				<button
+					class="flex aspect-square w-16 flex-row items-center justify-center gap-2 rounded-md p-2 hover:bg-muted {$selectedCrops[
+						crop
+					]
+						? 'bg-primary/15'
+						: ''}"
+					onclick={() => click(crop)}
+				>
+					<img {src} alt={crop[0]} class="pixelated aspect-square h-12" />
+				</button>
+			{/each}
+		</div>
+	</ScrollArea>
 </svelte:element>

--- a/src/components/stats/jacob/contest-list.svelte
+++ b/src/components/stats/jacob/contest-list.svelte
@@ -2,18 +2,30 @@
 	import Contest from '$comp/stats/jacob/contest.svelte';
 	import { ScrollArea } from '$ui/scroll-area';
 	import type { components } from '$lib/api/api';
+	import { Button } from '$ui/button';
+	import { page } from '$app/state';
 
 	interface Props {
 		contests: NonNullable<components['schemas']['JacobDataDto']['contests']>;
+		remining?: number;
 	}
 
-	let { contests }: Props = $props();
+	let { contests, remining = 0 }: Props = $props();
 </script>
 
 <ScrollArea orientation="vertical" class="h-96">
-	<div class="grid grid-cols-1 items-center justify-center gap-2 px-3 md:grid-cols-2">
+	<div class="flex flex-wrap items-center justify-center gap-2 px-3">
 		{#each contests as contest (`${contest.crop}${contest.timestamp}`)}
-			<Contest {contest} class="w-full" />
+			<Contest {contest} class="" />
 		{/each}
 	</div>
+	{#if remining > 0}
+		<div class="mt-4 flex flex-col items-center justify-center gap-2">
+			<p>
+				<span class="text-lg font-semibold">{remining.toLocaleString()}</span>
+				<span>not shown</span>
+			</p>
+			<Button href={page.url.pathname + '/contests'} variant="outline">View All</Button>
+		</div>
+	{/if}
 </ScrollArea>

--- a/src/components/stats/jacob/contest-list.svelte
+++ b/src/components/stats/jacob/contest-list.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import Contest from '$comp/stats/jacob/contest.svelte';
+	import { ScrollArea } from '$ui/scroll-area';
+	import type { components } from '$lib/api/api';
+
+	interface Props {
+		contests: NonNullable<components['schemas']['JacobDataDto']['contests']>;
+	}
+
+	let { contests }: Props = $props();
+</script>
+
+<ScrollArea orientation="vertical" class="h-96">
+	<div class="grid grid-cols-1 items-center justify-center gap-2 px-3 md:grid-cols-2">
+		{#each contests as contest (`${contest.crop}${contest.timestamp}`)}
+			<Contest {contest} class="w-full" />
+		{/each}
+	</div>
+</ScrollArea>

--- a/src/components/stats/jacob/contest.svelte
+++ b/src/components/stats/jacob/contest.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import type { components } from '$lib/api/api';
 	import { getReadableSkyblockDate } from '$lib/format';
+	import { cn } from '$lib/utils';
 
 	interface Props {
 		contest: components['schemas']['ContestParticipationDto'];
 		irlTime?: boolean;
+		class?: string;
 	}
 
-	let { contest, irlTime = false }: Props = $props();
+	let { contest, irlTime = false, class: classes = '' }: Props = $props();
 
 	let { crop, position, participants, collected, timestamp, medal } = $derived(contest);
 
@@ -18,22 +20,25 @@
 <a
 	href="/contest/{timestamp}"
 	data-sveltekit-preload-data="off"
-	class="flex flex-col gap-0.5 rounded-md border-l-4 bg-primary-foreground p-2 hover:bg-muted hover:shadow-lg {crop?.replace(
-		' ',
-		''
-	)}"
+	class={cn(
+		`flex min-w-52 flex-col gap-1 rounded-md border-l-4 bg-primary-foreground p-2 hover:bg-muted hover:shadow-lg ${crop?.replace(
+			' ',
+			''
+		)}`,
+		classes
+	)}
 >
-	<h3 class="text-sm first-letter:uppercase">
+	<p class="text-sm first-letter:uppercase">
 		<span class="rounded-md bg-card p-0.5 px-1.5">{cropName}</span>
 		<span class="text-sm font-semibold">{ranking ? `#${(position ?? -2) + 1}` : 'Unclaimed'}</span>
 		<span class="text-xs">{ranking ? `/ ${participants}` : ''}</span>
-	</h3>
-	<h3 class="flex flex-row items-center gap-1 text-lg font-semibold">
+	</p>
+	<p class="flex flex-row items-center gap-1 text-lg font-semibold">
 		{#if medal && medal !== 'none'}
 			<img class="pixelated inline-block h-6 w-6 p-0.5" src="/images/medals/{medal}.webp" alt="Earned Medal" />
 		{/if}
-		{(collected ?? 0).toLocaleString()}
-	</h3>
+		<span>{(collected ?? 0).toLocaleString()}</span>
+	</p>
 	{#if irlTime}
 		<span class="font-mono text-xs font-semibold">
 			{new Date((timestamp ?? 0) * 1000).toLocaleString(undefined, {

--- a/src/components/stats/jacob/crop-medal-counts.svelte
+++ b/src/components/stats/jacob/crop-medal-counts.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { components } from '$lib/api/api';
+
+	interface Props {
+		contests: components['schemas']['ContestParticipationDto'][];
+	}
+
+	let { contests }: Props = $props();
+
+	const medals = ['bronze', 'silver', 'gold', 'platinum', 'diamond'];
+
+	let counts = $derived(
+		contests.reduce(
+			(acc, contest) => {
+				if (!contest.medal || contest.medal === 'none') return acc;
+
+				acc[contest.medal] ??= 0;
+				acc[contest.medal] += 1;
+				return acc;
+			},
+			{} as Record<string, number>
+		)
+	);
+</script>
+
+<div class="flex flex-wrap justify-center gap-2 md:flex-row">
+	{#each medals as medal (medal)}
+		{@const amount = counts[medal] ?? 0}
+		<div
+			class="flex flex-1 basis-8 items-center justify-center gap-2 rounded-md bg-primary-foreground px-2 py-1 md:px-4"
+		>
+			<img src="/images/medals/{medal}.webp" alt="Medal" class="pixelated h-6 w-6" />
+			<p class="text-xl font-semibold">
+				{amount.toLocaleString()}
+			</p>
+		</div>
+	{/each}
+</div>

--- a/src/components/stats/jacob/crop-medal-counts.svelte
+++ b/src/components/stats/jacob/crop-medal-counts.svelte
@@ -2,30 +2,17 @@
 	import type { components } from '$lib/api/api';
 
 	interface Props {
-		contests: components['schemas']['ContestParticipationDto'][];
+		stats: NonNullable<components['schemas']['JacobCropStatsDto']>;
 	}
 
-	let { contests }: Props = $props();
+	let { stats }: Props = $props();
 
-	const medals = ['bronze', 'silver', 'gold', 'platinum', 'diamond'];
-
-	let counts = $derived(
-		contests.reduce(
-			(acc, contest) => {
-				if (!contest.medal || contest.medal === 'none') return acc;
-
-				acc[contest.medal] ??= 0;
-				acc[contest.medal] += 1;
-				return acc;
-			},
-			{} as Record<string, number>
-		)
-	);
+	const medals = ['bronze', 'silver', 'gold', 'platinum', 'diamond'] as (keyof typeof stats.medals)[];
 </script>
 
 <div class="flex flex-wrap justify-center gap-2 md:flex-row">
 	{#each medals as medal (medal)}
-		{@const amount = counts[medal] ?? 0}
+		{@const amount = stats.medals?.[medal] ?? 0}
 		<div
 			class="flex flex-1 basis-8 items-center justify-center gap-2 rounded-md bg-primary-foreground px-2 py-1 md:px-4"
 		>

--- a/src/components/stats/jacob/crop-stats.svelte
+++ b/src/components/stats/jacob/crop-stats.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import type { components } from '$lib/api/api';
+	import CropSelector from '../contests/crop-selector.svelte';
+	import { DEFAULT_SELECTED_CROPS, getSelectedCrops } from '$lib/stores/selectedCrops';
+	import CropMedalCounts from './crop-medal-counts.svelte';
+	import { CROP_TO_ELITE_CROP } from '$lib/constants/crops';
+	import { Crop, getCropFromName } from 'farming-weight';
+	import { onMount } from 'svelte';
+	import ContestList from './contest-list.svelte';
+
+	interface Props {
+		jacob: components['schemas']['JacobDataDto'] | undefined;
+		crop?: string;
+	}
+
+	let { jacob, crop: initalCrop = 'Wheat' }: Props = $props();
+
+	const contestsByCrop = $derived(
+		jacob?.contests?.reduce<Record<string, components['schemas']['ContestParticipationDto'][]>>((acc, contest) => {
+			if (!contest.crop) return acc;
+
+			acc[contest.crop] ??= [];
+			acc[contest.crop].push(contest);
+			return acc;
+		}, {}) ?? {}
+	);
+
+	const selectedCrops = getSelectedCrops();
+	const crop = $derived(Object.entries($selectedCrops).find(([_, value]) => value)?.[0] ?? initalCrop);
+	const cropKey = $derived(CROP_TO_ELITE_CROP[getCropFromName(crop) ?? Crop.Wheat]);
+	const cropStats = $derived(jacob?.stats?.crops?.[cropKey as keyof typeof jacob.stats.crops] ?? {});
+
+	const contests = $derived(contestsByCrop[crop] ?? []);
+
+	const recentContests = $derived(
+		contests?.sort((a, b) => (b?.timestamp ?? 0) - (a?.timestamp ?? 0)).slice(0, 30) ?? []
+	);
+
+	onMount(() => {
+		if (initalCrop) {
+			selectedCrops.set({ ...DEFAULT_SELECTED_CROPS, [initalCrop]: true });
+		}
+	});
+</script>
+
+<div class="flex flex-1 flex-col items-center justify-center gap-4">
+	<CropSelector radio={true} />
+
+	<div class="flex flex-col items-center justify-center gap-4">
+		<div class="flex flex-col items-center gap-2">
+			<CropMedalCounts stats={cropStats} />
+			<div class="flex flex-wrap gap-2">
+				<div class="flex flex-col items-center rounded-md bg-primary-foreground p-2">
+					<span
+						><span class="text-lg font-semibold">{cropStats.participations?.toLocaleString()}</span> Participations</span
+					>
+				</div>
+				<div class="flex flex-col items-center rounded-md bg-primary-foreground p-2">
+					<span
+						><span class="text-lg font-semibold">{cropStats.firstPlaceScores?.toLocaleString()}</span> First
+						Place Scores</span
+					>
+				</div>
+			</div>
+		</div>
+		<ContestList contests={recentContests} remining={contests.length - recentContests.length} />
+	</div>
+</div>

--- a/src/components/stats/jacob/crop-stats.svelte
+++ b/src/components/stats/jacob/crop-stats.svelte
@@ -26,7 +26,7 @@
 	);
 
 	const selectedCrops = getSelectedCrops();
-	const crop = $derived(Object.entries($selectedCrops).find(([_, value]) => value)?.[0] ?? initalCrop);
+	const crop = $derived(Object.entries($selectedCrops).find(([, value]) => value)?.[0] ?? initalCrop);
 	const cropKey = $derived(CROP_TO_ELITE_CROP[getCropFromName(crop) ?? Crop.Wheat]);
 	const cropStats = $derived(jacob?.stats?.crops?.[cropKey as keyof typeof jacob.stats.crops] ?? {});
 

--- a/src/components/stats/jacob/cropstats.svelte
+++ b/src/components/stats/jacob/cropstats.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
-	import * as Popover from '$ui/popover';
 	import type { components } from '$lib/api/api';
-	import { PROPER_CROP_TO_IMG } from '$lib/constants/crops';
-	import { fortuneFromPersonalBestContest, getCropFromName } from 'farming-weight';
-	import FortuneBreakdown from '$comp/items/tools/fortune-breakdown.svelte';
+	import JacobCropStats from './jacob-crop-stats.svelte';
 
 	interface Props {
 		jacob: components['schemas']['JacobDataDto'] | undefined | null;
@@ -28,75 +25,10 @@
 			) ?? {}
 		).sort()
 	);
-
-	function fortune(crop: string, collected: number) {
-		const c = getCropFromName(crop);
-		if (!c) return 0;
-		return fortuneFromPersonalBestContest(c, collected);
-	}
-
-	function pb(crop: string) {
-		const amount = jacob?.stats?.personalBests?.[crop.replace(' ', '') as keyof typeof jacob.stats.personalBests];
-		return amount ? +amount : undefined;
-	}
-
-	const medals = ['bronze', 'silver', 'gold', 'platinum', 'diamond'];
-
-	function medal(crop: string) {
-		const medal = jacob?.stats?.brackets?.[crop.replace(' ', '') as keyof typeof jacob.stats.brackets];
-		return medal ? medals[+medal - 1] : undefined;
-	}
 </script>
 
 <div class="flex max-w-6xl flex-wrap items-center justify-center gap-4">
 	{#each highest as [crop, amount] (crop)}
-		{@const unique = medal(crop)}
-		{@const score = pb(crop)}
-		{@const ff = fortune(crop, score ?? 0)}
-
-		<div
-			class="flex flex-1 basis-48 flex-row items-center justify-between gap-4 rounded-md bg-primary-foreground p-2 md:max-w-52"
-		>
-			<div class="flex flex-row items-center gap-2">
-				<img src={PROPER_CROP_TO_IMG[crop]} alt="Crop" class="pixelated h-12 w-12 p-1" />
-
-				<div class="flex flex-col items-start gap-1">
-					<div>
-						<Popover.Mobile>
-							{#snippet trigger()}
-								<p class="text-lg font-semibold leading-none">
-									{score?.toLocaleString() ?? 'Not Set!'}
-								</p>
-							{/snippet}
-							<div>
-								<p>The highest placement earned for {crop}!</p>
-							</div>
-						</Popover.Mobile>
-					</div>
-
-					<Popover.Mobile>
-						{#snippet trigger()}
-							<p class="participation-count text-lg leading-none">
-								x{amount.toLocaleString()}
-							</p>
-						{/snippet}
-						<div>
-							<p>The amount of participations for {crop}!</p>
-						</div>
-					</Popover.Mobile>
-				</div>
-			</div>
-
-			<div class="flex flex-col items-end gap-1">
-				{#if unique}
-					<img
-						src="/images/medals/{unique}.webp"
-						alt="{unique} Medal"
-						class="pixelated highest-bracket h-10 w-10 p-1"
-					/>
-				{/if}
-				<FortuneBreakdown total={ff} small={true} max={100} />
-			</div>
-		</div>
+		<JacobCropStats {jacob} {crop} count={amount} />
 	{/each}
 </div>

--- a/src/components/stats/jacob/jacob-crop-stats.svelte
+++ b/src/components/stats/jacob/jacob-crop-stats.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import * as Popover from '$ui/popover';
+	import type { components } from '$lib/api/api';
+	import { PROPER_CROP_TO_IMG } from '$lib/constants/crops';
+	import { fortuneFromPersonalBestContest, getCropFromName } from 'farming-weight';
+	import FortuneBreakdown from '$comp/items/tools/fortune-breakdown.svelte';
+
+	interface Props {
+		jacob: components['schemas']['JacobDataDto'] | undefined | null;
+		crop: string;
+		count: number;
+	}
+
+	let { jacob, crop, count }: Props = $props();
+
+	function fortune(crop: string, collected: number) {
+		const c = getCropFromName(crop);
+		if (!c) return 0;
+		return fortuneFromPersonalBestContest(c, collected);
+	}
+
+	function pb(crop: string) {
+		const amount = jacob?.stats?.personalBests?.[crop.replace(' ', '') as keyof typeof jacob.stats.personalBests];
+		return amount ? +amount : undefined;
+	}
+
+	const medals = ['bronze', 'silver', 'gold', 'platinum', 'diamond'];
+
+	function medal(crop: string) {
+		const medal = jacob?.stats?.brackets?.[crop.replace(' ', '') as keyof typeof jacob.stats.brackets];
+		return medal ? medals[+medal - 1] : undefined;
+	}
+
+	const unique = $derived(medal(crop));
+	const score = $derived(pb(crop));
+	const ff = $derived(fortune(crop, score ?? 0));
+</script>
+
+<div
+	class="flex flex-1 basis-48 flex-row items-center justify-between gap-4 rounded-md bg-primary-foreground p-2 md:max-w-52"
+>
+	<div class="flex flex-row items-center gap-2">
+		<img src={PROPER_CROP_TO_IMG[crop]} alt="Crop" class="pixelated h-12 w-12 p-1" />
+
+		<div class="flex flex-col items-start gap-1">
+			<div>
+				<Popover.Mobile>
+					{#snippet trigger()}
+						<p class="text-lg font-semibold leading-none">
+							{score?.toLocaleString() ?? 'Not Set!'}
+						</p>
+					{/snippet}
+					<div>
+						<p>The highest placement earned for {crop}!</p>
+					</div>
+				</Popover.Mobile>
+			</div>
+
+			<Popover.Mobile>
+				{#snippet trigger()}
+					<p class="participation-count text-lg leading-none">
+						x{count.toLocaleString()}
+					</p>
+				{/snippet}
+				<div>
+					<p>The amount of participations for {crop}!</p>
+				</div>
+			</Popover.Mobile>
+		</div>
+	</div>
+
+	<div class="flex flex-col items-end gap-1">
+		{#if unique}
+			<img
+				src="/images/medals/{unique}.webp"
+				alt="{unique} Medal"
+				class="pixelated highest-bracket h-10 w-10 p-1"
+			/>
+		{/if}
+		<FortuneBreakdown total={ff} small={true} max={100} />
+	</div>
+</div>

--- a/src/components/stats/jacob/jacobinfo.svelte
+++ b/src/components/stats/jacob/jacobinfo.svelte
@@ -4,13 +4,9 @@
 	import Medals from './medals.svelte';
 	import Recents from './recents.svelte';
 	import Stats from './stats.svelte';
-	import { getSelectedCrops } from '$lib/stores/selectedCrops';
-	import { CROP_TO_ELITE_CROP } from '$lib/constants/crops';
-	import { Crop, getCropFromName } from 'farming-weight';
 
 	interface Props {
 		jacob: components['schemas']['JacobDataDto'] | undefined;
-		crop?: string;
 		ign: string;
 		ranks?: {
 			bronze: number;
@@ -35,25 +31,7 @@
 			participations: -1,
 			firstPlaces: -1,
 		},
-		crop: initalCrop = 'Wheat',
 	}: Props = $props();
-
-	const contestsByCrop = $derived(
-		jacob?.contests?.reduce<Record<string, components['schemas']['ContestParticipationDto'][]>>((acc, contest) => {
-			if (!contest.crop) return acc;
-
-			acc[contest.crop] ??= [];
-			acc[contest.crop].push(contest);
-			return acc;
-		}, {}) ?? {}
-	);
-
-	const selectedCrops = getSelectedCrops();
-	const crop = $derived(Object.entries($selectedCrops).find(([_, value]) => value)?.[0] ?? initalCrop);
-	const cropKey = $derived(CROP_TO_ELITE_CROP[getCropFromName(crop) ?? Crop.Wheat]);
-	const cropStats = $derived(jacob?.stats?.crops?.[cropKey as keyof typeof jacob.stats.crops] ?? {});
-
-	const contests = $derived(contestsByCrop[crop] ?? []);
 </script>
 
 <section class="mx-2 mb-8 flex-col justify-center gap-4 py-4 align-middle" aria-labelledby="Jacob">

--- a/src/components/stats/jacob/jacobinfo.svelte
+++ b/src/components/stats/jacob/jacobinfo.svelte
@@ -9,6 +9,8 @@
 	import { getSelectedCrops } from '$lib/stores/selectedCrops';
 	import RecentContests from './recent-contests.svelte';
 	import CropMedalCounts from './crop-medal-counts.svelte';
+	import { API_CROP_TO_CROP, CROP_TO_ELITE_CROP } from '$lib/constants/crops';
+	import { Crop, getCropFromName } from 'farming-weight';
 
 	interface Props {
 		jacob: components['schemas']['JacobDataDto'] | undefined;
@@ -52,6 +54,8 @@
 
 	const selectedCrops = getSelectedCrops();
 	const crop = $derived(Object.entries($selectedCrops).find(([_, value]) => value)?.[0] ?? initalCrop);
+	const cropKey = $derived(CROP_TO_ELITE_CROP[getCropFromName(crop) ?? Crop.Wheat]);
+	const cropStats = $derived(jacob?.stats?.crops?.[cropKey as keyof typeof jacob.stats.crops] ?? {});
 
 	const contests = $derived(contestsByCrop[crop] ?? []);
 </script>
@@ -62,11 +66,26 @@
 	<CropSelector radio={true} />
 
 	<Card.Root class="mx-auto max-w-7xl">
-		<Card.Content class="flex flex-col items-center justify-center gap-4 md:flex-row">
-			<div class="flex flex-col items-center gap-4">
-				<CropMedalCounts {contests} />
+		<Card.Content class="flex flex-col items-center justify-center gap-4">
+			<div class="flex flex-col items-center gap-2">
+				<CropMedalCounts stats={cropStats} />
+				<div class="flex flex-wrap gap-2">
+					<div class="flex flex-col items-center rounded-md bg-primary-foreground p-2">
+						<span
+							><span class="text-lg font-semibold">{cropStats.participations?.toLocaleString()}</span> Participations</span
+						>
+					</div>
+					<div class="flex flex-col items-center rounded-md bg-primary-foreground p-2">
+						<span
+							><span class="text-lg font-semibold">{cropStats.firstPlaceScores?.toLocaleString()}</span> First
+							Place Scores</span
+						>
+					</div>
+				</div>
 			</div>
-			<RecentContests {contests} />
+			<div class="flex flex-col items-center gap-4 md:flex-row">
+				<RecentContests {contests} />
+			</div>
 		</Card.Content>
 	</Card.Root>
 	<!-- <div class="my-8 flex flex-row items-center justify-center">

--- a/src/components/stats/jacob/jacobinfo.svelte
+++ b/src/components/stats/jacob/jacobinfo.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
-	import * as Card from '$ui/card';
 	import type { components } from '$lib/api/api';
-	import CropSelector from '../contests/crop-selector.svelte';
 	import Cropstats from './cropstats.svelte';
 	import Medals from './medals.svelte';
 	import Recents from './recents.svelte';
 	import Stats from './stats.svelte';
 	import { getSelectedCrops } from '$lib/stores/selectedCrops';
-	import RecentContests from './recent-contests.svelte';
-	import CropMedalCounts from './crop-medal-counts.svelte';
-	import { API_CROP_TO_CROP, CROP_TO_ELITE_CROP } from '$lib/constants/crops';
+	import { CROP_TO_ELITE_CROP } from '$lib/constants/crops';
 	import { Crop, getCropFromName } from 'farming-weight';
 
 	interface Props {
@@ -62,35 +58,6 @@
 
 <section class="mx-2 mb-8 flex-col justify-center gap-4 py-4 align-middle" aria-labelledby="Jacob">
 	<h1 id="Jacob" class="pt-2 text-center text-3xl">{ign} &nbsp;-&nbsp; Jacob Stats</h1>
-
-	<CropSelector radio={true} />
-
-	<Card.Root class="mx-auto max-w-7xl">
-		<Card.Content class="flex flex-col items-center justify-center gap-4">
-			<div class="flex flex-col items-center gap-2">
-				<CropMedalCounts stats={cropStats} />
-				<div class="flex flex-wrap gap-2">
-					<div class="flex flex-col items-center rounded-md bg-primary-foreground p-2">
-						<span
-							><span class="text-lg font-semibold">{cropStats.participations?.toLocaleString()}</span> Participations</span
-						>
-					</div>
-					<div class="flex flex-col items-center rounded-md bg-primary-foreground p-2">
-						<span
-							><span class="text-lg font-semibold">{cropStats.firstPlaceScores?.toLocaleString()}</span> First
-							Place Scores</span
-						>
-					</div>
-				</div>
-			</div>
-			<div class="flex flex-col items-center gap-4 md:flex-row">
-				<RecentContests {contests} />
-			</div>
-		</Card.Content>
-	</Card.Root>
-	<!-- <div class="my-8 flex flex-row items-center justify-center">
-		<Cropstats {jacob} />
-	<!-- </div> -->
 
 	<div class="my-8 flex flex-row items-center justify-center">
 		<Cropstats {jacob} />

--- a/src/components/stats/jacob/jacobinfo.svelte
+++ b/src/components/stats/jacob/jacobinfo.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
+	import * as Card from '$ui/card';
 	import type { components } from '$lib/api/api';
+	import CropSelector from '../contests/crop-selector.svelte';
 	import Cropstats from './cropstats.svelte';
 	import Medals from './medals.svelte';
 	import Recents from './recents.svelte';
 	import Stats from './stats.svelte';
+	import { getSelectedCrops } from '$lib/stores/selectedCrops';
+	import RecentContests from './recent-contests.svelte';
+	import CropMedalCounts from './crop-medal-counts.svelte';
 
 	interface Props {
 		jacob: components['schemas']['JacobDataDto'] | undefined;
+		crop?: string;
 		ign: string;
 		ranks?: {
 			bronze: number;
@@ -31,11 +37,41 @@
 			participations: -1,
 			firstPlaces: -1,
 		},
+		crop: initalCrop = 'Wheat',
 	}: Props = $props();
+
+	const contestsByCrop = $derived(
+		jacob?.contests?.reduce<Record<string, components['schemas']['ContestParticipationDto'][]>>((acc, contest) => {
+			if (!contest.crop) return acc;
+
+			acc[contest.crop] ??= [];
+			acc[contest.crop].push(contest);
+			return acc;
+		}, {}) ?? {}
+	);
+
+	const selectedCrops = getSelectedCrops();
+	const crop = $derived(Object.entries($selectedCrops).find(([_, value]) => value)?.[0] ?? initalCrop);
+
+	const contests = $derived(contestsByCrop[crop] ?? []);
 </script>
 
 <section class="mx-2 mb-8 flex-col justify-center gap-4 py-4 align-middle" aria-labelledby="Jacob">
 	<h1 id="Jacob" class="pt-2 text-center text-3xl">{ign} &nbsp;-&nbsp; Jacob Stats</h1>
+
+	<CropSelector radio={true} />
+
+	<Card.Root class="mx-auto max-w-7xl">
+		<Card.Content class="flex flex-col items-center justify-center gap-4 md:flex-row">
+			<div class="flex flex-col items-center gap-4">
+				<CropMedalCounts {contests} />
+			</div>
+			<RecentContests {contests} />
+		</Card.Content>
+	</Card.Root>
+	<!-- <div class="my-8 flex flex-row items-center justify-center">
+		<Cropstats {jacob} />
+	<!-- </div> -->
 
 	<div class="my-8 flex flex-row items-center justify-center">
 		<Cropstats {jacob} />

--- a/src/components/stats/jacob/medalcounts.svelte
+++ b/src/components/stats/jacob/medalcounts.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import * as Popover from '$comp/ui/popover';
+
 	interface Props {
 		medals?: {
 			diamond: number;
@@ -22,22 +24,26 @@
 	}: Props = $props();
 </script>
 
-<div class="flex flex-col justify-evenly gap-2 md:flex-row md:gap-4">
+<div class="flex flex-wrap justify-center gap-2 md:flex-row md:gap-4">
 	{#if participations}
-		<div
-			class="flex flex-1 items-baseline justify-center gap-2 rounded-md bg-gray-100 p-2 dark:bg-zinc-800 md:px-4"
-		>
-			<p class="text-2xl font-semibold text-red-700">
-				{participations.toLocaleString()}
-			</p>
-			<h2>Contest{participations > 1 ? 's' : ''}</h2>
+		<div class="flex flex-1 items-center justify-center gap-2 rounded-md bg-primary-foreground">
+			<Popover.Mobile>
+				{#snippet trigger()}
+					<p class="p-2 text-xl font-semibold leading-none md:px-2">
+						{participations.toLocaleString()}
+					</p>
+				{/snippet}
+				<div>
+					<p>The number of contests participated in!</p>
+				</div>
+			</Popover.Mobile>
 		</div>
 	{/if}
 	{#each Object.entries(medals) as [medal, amount] (medal)}
 		<div
-			class="flex flex-1 basis-8 items-center justify-center gap-2 rounded-md bg-gray-100 p-2 dark:bg-zinc-800 md:px-4"
+			class="flex min-w-16 max-w-24 flex-1 basis-8 items-center justify-center gap-2 rounded-md bg-primary-foreground p-1 md:p-2"
 		>
-			<img src="/images/medals/{medal}.webp" alt="Medal" class="pixelated h-8 w-8" />
+			<img src="/images/medals/{medal}.webp" alt={medal} class="pixelated size-6 md:size-8" />
 			<p class="text-2xl font-semibold">
 				{amount.toLocaleString()}
 			</p>

--- a/src/components/stats/jacob/medalcounts.svelte
+++ b/src/components/stats/jacob/medalcounts.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import * as Popover from '$comp/ui/popover';
+	import * as Popover from '$ui/popover';
 
 	interface Props {
 		medals?: {

--- a/src/components/stats/jacob/recent-contests.svelte
+++ b/src/components/stats/jacob/recent-contests.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import Contest from '$comp/stats/jacob/contest.svelte';
-	import { ScrollArea } from '$ui/scroll-area';
 	import type { components } from '$lib/api/api';
 	import { Button } from '$ui/button';
+	import ContestList from './contest-list.svelte';
 
 	interface Props {
 		contests: components['schemas']['JacobDataDto']['contests'];
@@ -17,8 +16,6 @@
 			?.sort((a, b) => (b?.timestamp ?? 0) - (a?.timestamp ?? 0))
 			.slice(0, 30) ?? []
 	);
-
-	let showMore = false;
 </script>
 
 <div class="flex flex-col items-center md:items-start">
@@ -26,13 +23,7 @@
 
 	{#if recentContests.length > 0}
 		<div class="flex flex-col items-center gap-2">
-			<ScrollArea orientation="vertical" class="h-96">
-				<div class="grid grid-cols-1 items-center justify-center gap-2 px-3 md:grid-cols-2">
-					{#each recentContests as contest (`${contest.crop}${contest.timestamp}`)}
-						<Contest {contest} class="w-full" />
-					{/each}
-				</div>
-			</ScrollArea>
+			<ContestList contests={recentContests} />
 			<Button
 				href={page.url.pathname + '/contests'}
 				data-sveltekit-preload-data="off"

--- a/src/components/stats/jacob/recent-contests.svelte
+++ b/src/components/stats/jacob/recent-contests.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import Contest from '$comp/stats/jacob/contest.svelte';
+	import { ScrollArea } from '$ui/scroll-area';
+	import type { components } from '$lib/api/api';
+	import { Button } from '$ui/button';
+
+	interface Props {
+		contests: components['schemas']['JacobDataDto']['contests'];
+	}
+
+	let { contests }: Props = $props();
+
+	let recentContests = $derived(
+		contests
+			?.slice()
+			?.sort((a, b) => (b?.timestamp ?? 0) - (a?.timestamp ?? 0))
+			.slice(0, 30) ?? []
+	);
+
+	let showMore = false;
+</script>
+
+<div class="flex flex-col items-center md:items-start">
+	<h1 class="my-2 text-2xl">Recent Contests</h1>
+
+	{#if recentContests.length > 0}
+		<div class="flex flex-col items-center gap-2">
+			<ScrollArea orientation="vertical" class="h-96">
+				<div class="grid grid-cols-1 items-center justify-center gap-2 px-3 md:grid-cols-2">
+					{#each recentContests as contest (`${contest.crop}${contest.timestamp}`)}
+						<Contest {contest} class="w-full" />
+					{/each}
+				</div>
+			</ScrollArea>
+			<Button
+				href={page.url.pathname + '/contests'}
+				data-sveltekit-preload-data="off"
+				class="w-48"
+				variant="outline"
+			>
+				View All
+			</Button>
+		</div>
+	{:else}
+		<p class="text-lg">No contests found.</p>
+	{/if}
+</div>

--- a/src/components/ui/popover/popover-content.svelte
+++ b/src/components/ui/popover/popover-content.svelte
@@ -16,6 +16,9 @@
 		bind:ref
 		{sideOffset}
 		{align}
+		onCloseAutoFocus={(e) => {
+			e.preventDefault();
+		}}
 		class={cn(
 			'z-50 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
 			className

--- a/src/components/ui/scroll-area/scroll-area.svelte
+++ b/src/components/ui/scroll-area/scroll-area.svelte
@@ -5,6 +5,7 @@
 
 	let {
 		ref = $bindable(null),
+		viewRef = $bindable(null),
 		class: className,
 		orientation = 'vertical',
 		scrollbarXClasses = '',
@@ -15,11 +16,12 @@
 		orientation?: 'vertical' | 'horizontal' | 'both' | undefined;
 		scrollbarXClasses?: string | undefined;
 		scrollbarYClasses?: string | undefined;
+		viewRef?: ScrollAreaPrimitive.Viewport['$$prop_def']['ref'];
 	} = $props();
 </script>
 
 <ScrollAreaPrimitive.Root bind:ref {...restProps} class={cn('relative overflow-hidden', className)}>
-	<ScrollAreaPrimitive.Viewport class="h-full w-full rounded-[inherit]">
+	<ScrollAreaPrimitive.Viewport bind:ref={viewRef} class="h-full w-full rounded-[inherit]">
 		{@render children?.()}
 	</ScrollAreaPrimitive.Viewport>
 	{#if orientation === 'vertical' || orientation === 'both'}

--- a/src/lib/api/api.d.ts
+++ b/src/lib/api/api.d.ts
@@ -1038,6 +1038,64 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/guild/{guildId}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Refresh a Discord guild */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    guildId: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": string;
+                        "application/json": string;
+                        "text/json": string;
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": string;
+                        "application/json": string;
+                        "text/json": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/guild/{guildId}/events/admin": {
         parameters: {
             query?: never;
@@ -9595,6 +9653,15 @@ export interface components {
             brackets?: components["schemas"]["ContestBracketsDto"];
             participations?: components["schemas"]["StrippedContestParticipationDto"][];
         };
+        JacobCropStatsDto: {
+            /** Format: int32 */
+            participations?: number;
+            /** Format: int32 */
+            firstPlaceScores?: number;
+            /** Format: int32 */
+            personalBestTimestamp?: number | null;
+            medals?: components["schemas"]["EarnedMedalInventoryDto"];
+        };
         JacobDataDto: {
             medals?: components["schemas"]["MedalInventoryDto"];
             earnedMedals?: components["schemas"]["EarnedMedalInventoryDto"];
@@ -9649,6 +9716,19 @@ export interface components {
                 Wheat?: number;
                 /** Format: int64 */
                 Seeds?: number;
+            };
+            crops?: {
+                Cactus?: components["schemas"]["JacobCropStatsDto"];
+                Carrot?: components["schemas"]["JacobCropStatsDto"];
+                CocoaBeans?: components["schemas"]["JacobCropStatsDto"];
+                Melon?: components["schemas"]["JacobCropStatsDto"];
+                Mushroom?: components["schemas"]["JacobCropStatsDto"];
+                NetherWart?: components["schemas"]["JacobCropStatsDto"];
+                Potato?: components["schemas"]["JacobCropStatsDto"];
+                Pumpkin?: components["schemas"]["JacobCropStatsDto"];
+                SugarCane?: components["schemas"]["JacobCropStatsDto"];
+                Wheat?: components["schemas"]["JacobCropStatsDto"];
+                Seeds?: components["schemas"]["JacobCropStatsDto"];
             };
         };
         Leaderboard: {
@@ -9809,6 +9889,8 @@ export interface components {
             slug?: number;
             /** Format: int32 */
             earthworm?: number;
+            /** Format: int32 */
+            mouse?: number | null;
         };
         PetDto: {
             uuid?: string | null;

--- a/src/lib/api/swagger.json
+++ b/src/lib/api/swagger.json
@@ -1350,6 +1350,76 @@
         ]
       }
     },
+    "/guild/{guildId}/refresh": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Refresh a Discord guild",
+        "parameters": [
+          {
+            "name": "guildId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
     "/guild/{guildId}/events/admin": {
       "get": {
         "tags": [
@@ -14977,6 +15047,28 @@
         },
         "additionalProperties": false
       },
+      "JacobCropStatsDto": {
+        "type": "object",
+        "properties": {
+          "participations": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "firstPlaceScores": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "personalBestTimestamp": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "medals": {
+            "$ref": "#/components/schemas/EarnedMedalInventoryDto"
+          }
+        },
+        "additionalProperties": false
+      },
       "JacobDataDto": {
         "type": "object",
         "properties": {
@@ -15111,6 +15203,45 @@
               "Seeds": {
                 "type": "integer",
                 "format": "int64"
+              }
+            },
+            "additionalProperties": false
+          },
+          "crops": {
+            "type": "object",
+            "properties": {
+              "Cactus": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "Carrot": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "CocoaBeans": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "Melon": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "Mushroom": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "NetherWart": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "Potato": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "Pumpkin": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "SugarCane": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "Wheat": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
+              },
+              "Seeds": {
+                "$ref": "#/components/schemas/JacobCropStatsDto"
               }
             },
             "additionalProperties": false
@@ -15577,6 +15708,11 @@
           "earthworm": {
             "type": "integer",
             "format": "int32"
+          },
+          "mouse": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/src/routes/(auth)/@[id=id]/[profile]/graphs/+page.svelte
+++ b/src/routes/(auth)/@[id=id]/[profile]/graphs/+page.svelte
@@ -7,7 +7,7 @@
 	import { Button } from '$ui/button';
 	import { Label } from '$ui/label';
 
-	import Cropselector from '$comp/stats/contests/cropselector.svelte';
+	import Cropselector from '$comp/stats/contests/crop-selector.svelte';
 	import Graph from '$comp/charts/collectiongraph.svelte';
 	import Head from '$comp/head.svelte';
 

--- a/src/routes/@[id=id]/[[profile]]/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/+page.svelte
@@ -13,6 +13,7 @@
 	import JacobInfo from '$comp/stats/jacob/jacobinfo.svelte';
 	import Farmingtools from '$comp/items/tools/farmingtools.svelte';
 	import ProfileEventMember from '$comp/events/profile-event-member.svelte';
+	import CropStats from '$comp/stats/jacob/crop-stats.svelte';
 	import Head from '$comp/head.svelte';
 
 	import type { PageData } from './$types';
@@ -39,6 +40,9 @@
 		member?.farmingWeight?.totalWeight?.toLocaleString(undefined, { maximumFractionDigits: 0 }) ?? 'Not Found!'
 	);
 
+	const topCollections = $derived(collections?.sort((a, b) => b.weight - a.weight).slice(0, 3));
+	const topCrop = $derived(getCropDisplayName(getCropFromName(topCollections?.[0]?.key ?? 'Wheat') ?? Crop.Wheat));
+
 	let description = $derived(
 		`🌾 Farming Weight - ${weightStr}` +
 			`${weightRank > 0 ? ` (#${weightRank})` : ''}\n` +
@@ -49,9 +53,7 @@
 			`${
 				(data.ranks?.misc?.skyblockxp ?? -1) > 0 ? ` (#${data.ranks?.misc?.skyblockxp?.toLocaleString()})` : ''
 			}\n\n` +
-			(collections
-				?.sort((a, b) => b.weight - a.weight)
-				.slice(0, 3)
+			(topCollections
 				.map((c) => {
 					const crop = getCropFromName(c.key) ?? Crop.Wheat;
 					const rank = data.ranks?.collections?.[c.key] ?? -1;
@@ -120,4 +122,13 @@
 	}}
 />
 
-<Breakdown weight={member?.farmingWeight} />
+<div class="my-8 flex items-center justify-center">
+	<div class="grid max-w-8xl grid-cols-1 items-center justify-center gap-4 lg:grid-cols-2 lg:items-start">
+		<div class="flex-1">
+			<CropStats jacob={member?.jacob} crop={topCrop} />
+		</div>
+		<div class="flex-1">
+			<Breakdown weight={member?.farmingWeight} />
+		</div>
+	</div>
+</div>

--- a/src/routes/@[id=id]/[[profile]]/charts/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/charts/+page.svelte
@@ -10,7 +10,7 @@
 	import * as Popover from '$ui/popover';
 	import { Crop, CROP_WEIGHT, getCropDisplayName, getCropFromName } from 'farming-weight';
 	import { PROPER_CROP_TO_IMG } from '$lib/constants/crops';
-	import Cropselector from '$comp/stats/contests/cropselector.svelte';
+	import Cropselector from '$comp/stats/contests/crop-selector.svelte';
 	import { getSelectedCrops, getAnyCropSelected } from '$lib/stores/selectedCrops';
 	import JumpLink from '$comp/jump-link.svelte';
 	import Head from '$comp/head.svelte';

--- a/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
@@ -34,7 +34,7 @@
 	import TriangleAlert from 'lucide-svelte/icons/triangle-alert';
 
 	import Fortunebreakdown from '$comp/items/tools/fortune-breakdown.svelte';
-	import Cropselector from '$comp/stats/contests/cropselector.svelte';
+	import Cropselector from '$comp/stats/contests/crop-selector.svelte';
 	import Head from '$comp/head.svelte';
 	import FarmingGear from '$comp/rates/farming-gear.svelte';
 	import FortuneBreakdown from '$comp/items/tools/fortune-breakdown.svelte';

--- a/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
@@ -90,6 +90,16 @@
 		$ratesData.selectedPet = pets.some((pet) => pet.pet.uuid === $ratesData.selectedPet)
 			? $ratesData.selectedPet
 			: undefined;
+
+		if (!$ratesData.selectedPet && pets.length > 0) {
+			pets.sort((a, b) => b.fortune - a.fortune);
+
+			$ratesData.selectedPet = pets[0]?.pet.uuid ?? undefined;
+			selectedPet = pets[0];
+
+			$player.selectPet(selectedPet);
+			player.refresh();
+		}
 	});
 
 	let selectedTool = $state<FarmingTool | undefined>(undefined);
@@ -419,7 +429,14 @@
 						title="{selectedCrop} Fortune"
 						total={$player.getCropFortune(selectedCropKey).fortune}
 						breakdown={$player.getCropFortune(selectedCropKey).breakdown}
-					/>
+					>
+						<p class="text-xs">
+							This fortune is not representative of the actual "{selectedCrop} Fortune" stat seen in-game.
+							Currently, it includes all crop-related options on this page instead of breaking up the fortune
+							into its components. For example, farming tools also have general fortune, but it's included
+							here instead.
+						</p>
+					</Fortunebreakdown>
 				</div>
 				<div class="flex w-full max-w-lg flex-row items-center justify-center gap-2 md:gap-4">
 					<img

--- a/src/routes/contests/[year=int]/records/+layout.svelte
+++ b/src/routes/contests/[year=int]/records/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import Head from '$comp/head.svelte';
-	import Cropselector from '$comp/stats/contests/cropselector.svelte';
+	import Cropselector from '$comp/stats/contests/crop-selector.svelte';
 	import { getTimeStamp } from '$lib/format';
 
 	interface Props {

--- a/src/routes/contests/upcoming/+page.svelte
+++ b/src/routes/contests/upcoming/+page.svelte
@@ -3,8 +3,8 @@
 	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 	import Upcoming from './upcoming.svelte';
-	import { PROPER_CROP_TO_IMG } from '$lib/constants/crops';
-	import Cropselect from '$comp/stats/contests/cropselect.svelte';
+	import { getAnyCropSelected, getSelectedCrops } from '$lib/stores/selectedCrops';
+	import CropSelector from '$comp/stats/contests/crop-selector.svelte';
 
 	interface Props {
 		data: PageData;
@@ -23,32 +23,8 @@
 		][]
 	);
 
-	let crops = $derived(Object.entries(PROPER_CROP_TO_IMG).sort(([a], [b]) => a.localeCompare(b)));
-	let cactus = $state(false);
-	let carrot = $state(false);
-	let cocoa = $state(false);
-	let melon = $state(false);
-	let mushroom = $state(false);
-	let netherwart = $state(false);
-	let potato = $state(false);
-	let pumpkin = $state(false);
-	let sugarcane = $state(false);
-	let wheat = $state(false);
-
-	let selected = $derived({
-		Cactus: cactus,
-		Carrot: carrot,
-		'Cocoa Beans': cocoa,
-		Melon: melon,
-		Mushroom: mushroom,
-		'Nether Wart': netherwart,
-		Potato: potato,
-		Pumpkin: pumpkin,
-		'Sugar Cane': sugarcane,
-		Wheat: wheat,
-	} as Record<string, boolean>);
-
-	let anySelected = $derived(Object.values(selected).some((v) => v));
+	let selected = getSelectedCrops();
+	let anySelected = getAnyCropSelected();
 
 	onMount(() => {
 		const interval = setInterval(() => {
@@ -68,24 +44,14 @@
 		<p>No upcoming contests have been provided yet! Try again later!</p>
 	{:else}
 		<div class="mb-8 flex flex-wrap gap-2">
-			<!-- Not amazing but an easy way to bind the values -->
-			<Cropselect bind:clicked={cactus} src={crops[0][1]} alt={crops[0][0]} />
-			<Cropselect bind:clicked={carrot} src={crops[1][1]} alt={crops[1][0]} />
-			<Cropselect bind:clicked={cocoa} src={crops[2][1]} alt={crops[2][0]} />
-			<Cropselect bind:clicked={melon} src={crops[3][1]} alt={crops[3][0]} />
-			<Cropselect bind:clicked={mushroom} src={crops[4][1]} alt={crops[4][0]} />
-			<Cropselect bind:clicked={netherwart} src={crops[5][1]} alt={crops[5][0]} />
-			<Cropselect bind:clicked={potato} src={crops[6][1]} alt={crops[6][0]} />
-			<Cropselect bind:clicked={pumpkin} src={crops[7][1]} alt={crops[7][0]} />
-			<Cropselect bind:clicked={sugarcane} src={crops[8][1]} alt={crops[8][0]} />
-			<Cropselect bind:clicked={wheat} src={crops[9][1]} alt={crops[9][0]} />
+			<CropSelector />
 		</div>
 		<div class="mx-8 flex w-full flex-col items-center justify-center gap-4 md:w-[70%]">
-			{#if current && (!anySelected || current[1].some((c) => selected[c]))}
+			{#if current && (!$anySelected || current[1].some((c) => $selected[c]))}
 				<Upcoming current={true} timestamp={+current[0]} crops={current[1]} currentSeconds={seconds} />
 			{/if}
 			{#each upcoming as [timestamp, contest] (timestamp)}
-				{#if !anySelected || contest.some((c) => selected[c])}
+				{#if !$anySelected || contest.some((c) => $selected[c])}
 					<Upcoming timestamp={+timestamp} crops={contest} currentSeconds={seconds} />
 				{/if}
 			{/each}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -114,6 +114,9 @@ export default {
 				'accordion-up': 'accordion-up 0.2s ease-out',
 				'caret-blink': 'caret-blink 1.25s ease-out infinite',
 			},
+			maxWidth: {
+				'8xl': '90rem',
+			},
 		},
 	},
 	ux: {


### PR DESCRIPTION
Adds a new section to the website for crop specific jacob stats. Will likely have filtering and specific leaderboards in the future.

![image](https://github.com/user-attachments/assets/d67a8c47-d8ce-4862-9132-3fd1658f968f)
