### PR TITLE
Fix names in sidebar

### DIFF
--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -25,7 +25,7 @@
 					{#snippet child({ props })}
 						<Sidebar.MenuButton {...props} class="text-sidebar-foreground/70">
 							{#snippet tooltipContent()}
-								<span class="inline-block">{title}</span>
+								<span class="inline-block first-letter:capitalize">{title}</span>
 							{/snippet}
 							{#if !sidebar.open && !sidebar.isMobile}
 								<ChevronRight
@@ -52,10 +52,6 @@
 </Sidebar.Group>
 
 {#snippet content(crumb: Crumb | Omit<Crumb, 'dropdown'>, open = false, drop = true)}
-	{@const name =
-		crumb.capitalize !== false && crumb.name
-			? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1)
-			: crumb?.name || ''}
 	{@const hasDrop = 'dropdown' in crumb && crumb.dropdown?.length}
 	{#if drop && 'dropdown' in crumb && crumb.dropdown?.length}
 		{#if sidebar.state === 'collapsed' && !sidebar.isMobile}
@@ -63,10 +59,15 @@
 				{#if crumb.href && !hasDrop}
 					{@render link(crumb)}
 				{:else}
-					<Sidebar.MenuButton class="truncate md:max-w-none" onclick={() => sidebar.toggle()}>
+					<Sidebar.MenuButton
+						class="truncate md:max-w-none {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+						onclick={() => sidebar.toggle()}
+					>
 						{@render inner(crumb)}
 						{#snippet tooltipContent()}
-							<span class="inline-block">{crumb.tooltip ?? name}</span>
+							<span class="inline-block {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+								>{crumb.tooltip ?? crumb.name}</span
+							>
 						{/snippet}
 					</Sidebar.MenuButton>
 				{/if}
@@ -79,7 +80,11 @@
 							<Sidebar.MenuButton {...props}>
 								{@render inner(crumb)}
 								{#snippet tooltipContent()}
-									<span class="inline-block">{crumb.tooltip ?? name}</span>
+									<span
+										class="inline-block {(crumb.capitalize ?? true)
+											? 'first-letter:capitalize'
+											: ''}">{crumb.tooltip ?? crumb.name}</span
+									>
 								{/snippet}
 								<ChevronRight
 									class="ml-auto transition-transform duration-200 group-data-[state=open]/subcollapsible:rotate-90"
@@ -104,10 +109,14 @@
 			{#if crumb.href && !hasDrop}
 				{@render link(crumb)}
 			{:else}
-				<Sidebar.MenuButton class="truncate md:max-w-none">
+				<Sidebar.MenuButton
+					class="truncate md:max-w-none {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+				>
 					{@render inner(crumb)}
 					{#snippet tooltipContent()}
-						<span class="inline-block">{crumb.tooltip ?? name}</span>
+						<span class="inline-block {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+							>{crumb.tooltip ?? crumb.name}</span
+						>
 					{/snippet}
 				</Sidebar.MenuButton>
 			{/if}
@@ -116,10 +125,6 @@
 {/snippet}
 
 {#snippet inner(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
-	{@const name =
-		crumb.capitalize !== false && crumb.name
-			? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1)
-			: crumb?.name || ''}
 	{#if crumb.icon}
 		{@const Icon = crumb.icon as Component}
 		<Icon class="size-4" {...crumb.data} />
@@ -127,20 +132,18 @@
 	{#if crumb.snippet}
 		{@render crumb.snippet(crumb)}
 	{:else if crumb.name}
-		<span class="max-w-28 truncate">
-			{name}
+		<span class="max-w-28 truncate {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}">
+			{crumb.name}
 		</span>
 	{/if}
 {/snippet}
 
 {#snippet link(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
-	{@const name =
-		crumb.capitalize !== false && crumb.name
-			? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1)
-			: crumb?.name || ''}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
-			<span class="inline-block">{crumb.tooltip ?? name}</span>
+			<span class="inline-block {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+				>{crumb.tooltip ?? crumb.name}</span
+			>
 		{/snippet}
 		{#snippet child({ props })}
 			<a href={crumb.href} {...props}>

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -60,12 +60,12 @@
 					{@render link(crumb)}
 				{:else}
 					<Sidebar.MenuButton
-						class="truncate md:max-w-none {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+						class="truncate md:max-w-none {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
 						onclick={() => sidebar.toggle()}
 					>
 						{@render inner(crumb)}
 						{#snippet tooltipContent()}
-							<span class="inline-block {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+							<span class="inline-block {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
 								>{crumb.tooltip ?? crumb.name}</span
 							>
 						{/snippet}
@@ -110,11 +110,11 @@
 				{@render link(crumb)}
 			{:else}
 				<Sidebar.MenuButton
-					class="truncate md:max-w-none {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+					class="truncate md:max-w-none {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
 				>
 					{@render inner(crumb)}
 					{#snippet tooltipContent()}
-						<span class="inline-block {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+						<span class="inline-block {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
 							>{crumb.tooltip ?? crumb.name}</span
 						>
 					{/snippet}
@@ -132,7 +132,7 @@
 	{#if crumb.snippet}
 		{@render crumb.snippet(crumb)}
 	{:else if crumb.name}
-		<span class="max-w-28 truncate {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}">
+		<span class="max-w-28 truncate {!crumb.capitalize ? '' : 'first-letter:capitalize'}">
 			{crumb.name}
 		</span>
 	{/if}
@@ -141,7 +141,7 @@
 {#snippet link(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
-			<span class="inline-block {(crumb.capitalize ?? true) ? 'first-letter:capitalize' : ''}"
+			<span class="inline-block {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
 				>{crumb.tooltip ?? crumb.name}</span
 			>
 		{/snippet}

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -52,7 +52,8 @@
 </Sidebar.Group>
 
 {#snippet content(crumb: Crumb | Omit<Crumb, 'dropdown'>, open = false, drop = true)}
-  {@const name = crumb.capitalize !== false ? crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1) : crumb.name}
+	{@const name =
+		crumb.capitalize !== false ? (crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1)) : crumb.name}
 	{@const hasDrop = 'dropdown' in crumb && crumb.dropdown?.length}
 	{#if drop && 'dropdown' in crumb && crumb.dropdown?.length}
 		{#if sidebar.state === 'collapsed' && !sidebar.isMobile}
@@ -113,7 +114,8 @@
 {/snippet}
 
 {#snippet inner(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
-	{@const name = crumb.capitalize !== false ? crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1) : crumb.name}
+	{@const name =
+		crumb.capitalize !== false ? (crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1)) : crumb.name}
 	{#if crumb.icon}
 		{@const Icon = crumb.icon as Component}
 		<Icon class="size-4" {...crumb.data} />
@@ -128,7 +130,8 @@
 {/snippet}
 
 {#snippet link(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
-	{@const name = crumb.capitalize !== false ? crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1) : crumb.name}
+	{@const name =
+		crumb.capitalize !== false ? (crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1)) : crumb.name}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
 			<span class="inline-block">{crumb.tooltip ?? name}</span>

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -25,7 +25,7 @@
 					{#snippet child({ props })}
 						<Sidebar.MenuButton {...props} class="text-sidebar-foreground/70">
 							{#snippet tooltipContent()}
-								<span class="inline-blockname">{title}</span>
+								<span class="inline-block">{title}</span>
 							{/snippet}
 							{#if !sidebar.open && !sidebar.isMobile}
 								<ChevronRight
@@ -60,10 +60,10 @@
 				{#if crumb.href && !hasDrop}
 					{@render link(crumb)}
 				{:else}
-					<Sidebar.MenuButton class="truncatename md:max-w-none" onclick={() => sidebar.toggle()}>
+					<Sidebar.MenuButton class="truncate md:max-w-none" onclick={() => sidebar.toggle()}>
 						{@render inner(crumb)}
 						{#snippet tooltipContent()}
-							<span class="inline-blockname">{crumb.tooltip ?? name}</span>
+							<span class="inline-block">{crumb.tooltip ?? name}</span>
 						{/snippet}
 					</Sidebar.MenuButton>
 				{/if}
@@ -76,7 +76,7 @@
 							<Sidebar.MenuButton {...props}>
 								{@render inner(crumb)}
 								{#snippet tooltipContent()}
-									<span class="inline-blockname">{crumb.tooltip ?? name}</span>
+									<span class="inline-block">{crumb.tooltip ?? name}</span>
 								{/snippet}
 								<ChevronRight
 									class="ml-auto transition-transform duration-200 group-data-[state=open]/subcollapsible:rotate-90"
@@ -101,10 +101,10 @@
 			{#if crumb.href && !hasDrop}
 				{@render link(crumb)}
 			{:else}
-				<Sidebar.MenuButton class="truncatename md:max-w-none">
+				<Sidebar.MenuButton class="truncate md:max-w-none">
 					{@render inner(crumb)}
 					{#snippet tooltipContent()}
-						<span class="inline-blockname">{crumb.tooltip ?? name}</span>
+						<span class="inline-block">{crumb.tooltip ?? name}</span>
 					{/snippet}
 				</Sidebar.MenuButton>
 			{/if}
@@ -131,7 +131,7 @@
 	{@const name = crumb.capitalize !== false ? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1) : crumb.name}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
-			<span class="inline-blockname">{crumb.tooltip ?? name}</span>
+			<span class="inline-block">{crumb.tooltip ?? name}</span>
 		{/snippet}
 		{#snippet child({ props })}
 			<a href={crumb.href} {...props}>

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -25,7 +25,7 @@
 					{#snippet child({ props })}
 						<Sidebar.MenuButton {...props} class="text-sidebar-foreground/70">
 							{#snippet tooltipContent()}
-								<span class="inline-block first-letter:capitalize">{title}</span>
+								<span class="inline-blockname">{title}</span>
 							{/snippet}
 							{#if !sidebar.open && !sidebar.isMobile}
 								<ChevronRight
@@ -52,6 +52,7 @@
 </Sidebar.Group>
 
 {#snippet content(crumb: Crumb | Omit<Crumb, 'dropdown'>, open = false, drop = true)}
+	{@const name = crumb.capitalize !== false ? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1) : crumb.name}
 	{@const hasDrop = 'dropdown' in crumb && crumb.dropdown?.length}
 	{#if drop && 'dropdown' in crumb && crumb.dropdown?.length}
 		{#if sidebar.state === 'collapsed' && !sidebar.isMobile}
@@ -59,13 +60,10 @@
 				{#if crumb.href && !hasDrop}
 					{@render link(crumb)}
 				{:else}
-					<Sidebar.MenuButton
-						class="truncate first-letter:capitalize md:max-w-none"
-						onclick={() => sidebar.toggle()}
-					>
+					<Sidebar.MenuButton class="truncatename md:max-w-none" onclick={() => sidebar.toggle()}>
 						{@render inner(crumb)}
 						{#snippet tooltipContent()}
-							<span class="inline-block first-letter:capitalize">{crumb.tooltip ?? crumb.name}</span>
+							<span class="inline-blockname">{crumb.tooltip ?? name}</span>
 						{/snippet}
 					</Sidebar.MenuButton>
 				{/if}
@@ -78,9 +76,7 @@
 							<Sidebar.MenuButton {...props}>
 								{@render inner(crumb)}
 								{#snippet tooltipContent()}
-									<span class="inline-block first-letter:capitalize"
-										>{crumb.tooltip ?? crumb.name}</span
-									>
+									<span class="inline-blockname">{crumb.tooltip ?? name}</span>
 								{/snippet}
 								<ChevronRight
 									class="ml-auto transition-transform duration-200 group-data-[state=open]/subcollapsible:rotate-90"
@@ -105,10 +101,10 @@
 			{#if crumb.href && !hasDrop}
 				{@render link(crumb)}
 			{:else}
-				<Sidebar.MenuButton class="truncate first-letter:capitalize md:max-w-none">
+				<Sidebar.MenuButton class="truncatename md:max-w-none">
 					{@render inner(crumb)}
 					{#snippet tooltipContent()}
-						<span class="inline-block first-letter:capitalize">{crumb.tooltip ?? crumb.name}</span>
+						<span class="inline-blockname">{crumb.tooltip ?? name}</span>
 					{/snippet}
 				</Sidebar.MenuButton>
 			{/if}
@@ -117,6 +113,7 @@
 {/snippet}
 
 {#snippet inner(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
+	{@const name = crumb.capitalize !== false ? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1) : crumb.name}
 	{#if crumb.icon}
 		{@const Icon = crumb.icon as Component}
 		<Icon class="size-4" {...crumb.data} />
@@ -125,19 +122,16 @@
 		{@render crumb.snippet(crumb)}
 	{:else if crumb.name}
 		<span class="max-w-28 truncate">
-			{#if crumb.capitalize !== false}
-				{crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1)}
-			{:else}
-				{crumb.name}
-			{/if}
+			{name}
 		</span>
 	{/if}
 {/snippet}
 
 {#snippet link(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
+	{@const name = crumb.capitalize !== false ? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1) : crumb.name}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
-			<span class="inline-block first-letter:capitalize">{crumb.tooltip ?? crumb.name}</span>
+			<span class="inline-blockname">{crumb.tooltip ?? name}</span>
 		{/snippet}
 		{#snippet child({ props })}
 			<a href={crumb.href} {...props}>

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -76,11 +76,7 @@
 							<Sidebar.MenuButton {...props}>
 								{@render inner(crumb)}
 								{#snippet tooltipContent()}
-									<span
-										class="inline-block {(crumb.capitalize ?? true)
-											? 'first-letter:capitalize'
-											: ''}">{crumb.tooltip ?? crumb.name}</span
-									>
+									<span class="inline-block {capital}">{crumb.tooltip ?? crumb.name}</span>
 								{/snippet}
 								<ChevronRight
 									class="ml-auto transition-transform duration-200 group-data-[state=open]/subcollapsible:rotate-90"

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -52,7 +52,7 @@
 </Sidebar.Group>
 
 {#snippet content(crumb: Crumb | Omit<Crumb, 'dropdown'>, open = false, drop = true)}
-	{@const name = crumb.capitalize !== false ? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1) : crumb.name}
+  {@const name = crumb.capitalize !== false ? crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1) : crumb.name}
 	{@const hasDrop = 'dropdown' in crumb && crumb.dropdown?.length}
 	{#if drop && 'dropdown' in crumb && crumb.dropdown?.length}
 		{#if sidebar.state === 'collapsed' && !sidebar.isMobile}
@@ -113,7 +113,7 @@
 {/snippet}
 
 {#snippet inner(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
-	{@const name = crumb.capitalize !== false ? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1) : crumb.name}
+	{@const name = crumb.capitalize !== false ? crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1) : crumb.name}
 	{#if crumb.icon}
 		{@const Icon = crumb.icon as Component}
 		<Icon class="size-4" {...crumb.data} />
@@ -128,7 +128,7 @@
 {/snippet}
 
 {#snippet link(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
-	{@const name = crumb.capitalize !== false ? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1) : crumb.name}
+	{@const name = crumb.capitalize !== false ? crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1) : crumb.name}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
 			<span class="inline-block">{crumb.tooltip ?? name}</span>

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -52,7 +52,7 @@
 </Sidebar.Group>
 
 {#snippet content(crumb: Crumb | Omit<Crumb, 'dropdown'>, open = false, drop = true)}
-  {@const capital = crumb.capitalize === false ? '' : 'first-letter:capitalize'}
+	{@const capital = crumb.capitalize === false ? '' : 'first-letter:capitalize'}
 	{@const hasDrop = 'dropdown' in crumb && crumb.dropdown?.length}
 	{#if drop && 'dropdown' in crumb && crumb.dropdown?.length}
 		{#if sidebar.state === 'collapsed' && !sidebar.isMobile}
@@ -60,15 +60,10 @@
 				{#if crumb.href && !hasDrop}
 					{@render link(crumb)}
 				{:else}
-					<Sidebar.MenuButton
-						class="truncate md:max-w-none {capital}"
-						onclick={() => sidebar.toggle()}
-					>
+					<Sidebar.MenuButton class="truncate md:max-w-none {capital}" onclick={() => sidebar.toggle()}>
 						{@render inner(crumb)}
 						{#snippet tooltipContent()}
-							<span class="inline-block {capital}"
-								>{crumb.tooltip ?? crumb.name}</span
-							>
+							<span class="inline-block {capital}">{crumb.tooltip ?? crumb.name}</span>
 						{/snippet}
 					</Sidebar.MenuButton>
 				{/if}
@@ -110,14 +105,10 @@
 			{#if crumb.href && !hasDrop}
 				{@render link(crumb)}
 			{:else}
-				<Sidebar.MenuButton
-					class="truncate md:max-w-none {capital}"
-				>
+				<Sidebar.MenuButton class="truncate md:max-w-none {capital}">
 					{@render inner(crumb)}
 					{#snippet tooltipContent()}
-						<span class="inline-block {capital}"
-							>{crumb.tooltip ?? crumb.name}</span
-						>
+						<span class="inline-block {capital}">{crumb.tooltip ?? crumb.name}</span>
 					{/snippet}
 				</Sidebar.MenuButton>
 			{/if}
@@ -126,7 +117,7 @@
 {/snippet}
 
 {#snippet inner(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
-  {@const capital = crumb.capitalize === false ? '' : 'first-letter:capitalize'}
+	{@const capital = crumb.capitalize === false ? '' : 'first-letter:capitalize'}
 	{#if crumb.icon}
 		{@const Icon = crumb.icon as Component}
 		<Icon class="size-4" {...crumb.data} />
@@ -141,12 +132,10 @@
 {/snippet}
 
 {#snippet link(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
-  {@const capital = crumb.capitalize === false ? '' : 'first-letter:capitalize'}
+	{@const capital = crumb.capitalize === false ? '' : 'first-letter:capitalize'}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
-			<span class="inline-block {capital}"
-				>{crumb.tooltip ?? crumb.name}</span
-			>
+			<span class="inline-block {capital}">{crumb.tooltip ?? crumb.name}</span>
 		{/snippet}
 		{#snippet child({ props })}
 			<a href={crumb.href} {...props}>

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -53,7 +53,9 @@
 
 {#snippet content(crumb: Crumb | Omit<Crumb, 'dropdown'>, open = false, drop = true)}
 	{@const name =
-		crumb.capitalize !== false ? (crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1)) : crumb.name}
+		crumb.capitalize !== false && crumb.name
+			? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1)
+			: crumb?.name || ''}
 	{@const hasDrop = 'dropdown' in crumb && crumb.dropdown?.length}
 	{#if drop && 'dropdown' in crumb && crumb.dropdown?.length}
 		{#if sidebar.state === 'collapsed' && !sidebar.isMobile}
@@ -115,7 +117,9 @@
 
 {#snippet inner(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
 	{@const name =
-		crumb.capitalize !== false ? (crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1)) : crumb.name}
+		crumb.capitalize !== false && crumb.name
+			? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1)
+			: crumb?.name || ''}
 	{#if crumb.icon}
 		{@const Icon = crumb.icon as Component}
 		<Icon class="size-4" {...crumb.data} />
@@ -131,7 +135,9 @@
 
 {#snippet link(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
 	{@const name =
-		crumb.capitalize !== false ? (crumb.name?.charAt(0).toUpperCase() ?? '' + crumb.name?.slice(1)) : crumb.name}
+		crumb.capitalize !== false && crumb.name
+			? crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1)
+			: crumb?.name || ''}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
 			<span class="inline-block">{crumb.tooltip ?? name}</span>

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -124,8 +124,12 @@
 	{#if crumb.snippet}
 		{@render crumb.snippet(crumb)}
 	{:else if crumb.name}
-		<span class="max-w-28 truncate first-letter:capitalize">
-			{crumb.name}
+		<span class="max-w-28 truncate">
+			{#if crumb.capitalize !== false}
+				{crumb.name.charAt(0).toUpperCase() + crumb.name.slice(1)}
+			{:else}
+				{crumb.name}
+			{/if}
 		</span>
 	{/if}
 {/snippet}

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -60,12 +60,12 @@
 					{@render link(crumb)}
 				{:else}
 					<Sidebar.MenuButton
-						class="truncate md:max-w-none {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
+						class="truncate md:max-w-none {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
 						onclick={() => sidebar.toggle()}
 					>
 						{@render inner(crumb)}
 						{#snippet tooltipContent()}
-							<span class="inline-block {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
+							<span class="inline-block {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
 								>{crumb.tooltip ?? crumb.name}</span
 							>
 						{/snippet}
@@ -110,11 +110,11 @@
 				{@render link(crumb)}
 			{:else}
 				<Sidebar.MenuButton
-					class="truncate md:max-w-none {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
+					class="truncate md:max-w-none {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
 				>
 					{@render inner(crumb)}
 					{#snippet tooltipContent()}
-						<span class="inline-block {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
+						<span class="inline-block {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
 							>{crumb.tooltip ?? crumb.name}</span
 						>
 					{/snippet}
@@ -132,7 +132,7 @@
 	{#if crumb.snippet}
 		{@render crumb.snippet(crumb)}
 	{:else if crumb.name}
-		<span class="max-w-28 truncate {!crumb.capitalize ? '' : 'first-letter:capitalize'}">
+		<span class="max-w-28 truncate {crumb.capitalize === false ? '' : 'first-letter:capitalize'}">
 			{crumb.name}
 		</span>
 	{/if}
@@ -141,7 +141,7 @@
 {#snippet link(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
-			<span class="inline-block {!crumb.capitalize ? '' : 'first-letter:capitalize'}"
+			<span class="inline-block {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
 				>{crumb.tooltip ?? crumb.name}</span
 			>
 		{/snippet}

--- a/src/components/sidebar/nav-dynamic.svelte
+++ b/src/components/sidebar/nav-dynamic.svelte
@@ -52,6 +52,7 @@
 </Sidebar.Group>
 
 {#snippet content(crumb: Crumb | Omit<Crumb, 'dropdown'>, open = false, drop = true)}
+  {@const capital = crumb.capitalize === false ? '' : 'first-letter:capitalize'}
 	{@const hasDrop = 'dropdown' in crumb && crumb.dropdown?.length}
 	{#if drop && 'dropdown' in crumb && crumb.dropdown?.length}
 		{#if sidebar.state === 'collapsed' && !sidebar.isMobile}
@@ -60,12 +61,12 @@
 					{@render link(crumb)}
 				{:else}
 					<Sidebar.MenuButton
-						class="truncate md:max-w-none {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
+						class="truncate md:max-w-none {capital}"
 						onclick={() => sidebar.toggle()}
 					>
 						{@render inner(crumb)}
 						{#snippet tooltipContent()}
-							<span class="inline-block {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
+							<span class="inline-block {capital}"
 								>{crumb.tooltip ?? crumb.name}</span
 							>
 						{/snippet}
@@ -110,11 +111,11 @@
 				{@render link(crumb)}
 			{:else}
 				<Sidebar.MenuButton
-					class="truncate md:max-w-none {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
+					class="truncate md:max-w-none {capital}"
 				>
 					{@render inner(crumb)}
 					{#snippet tooltipContent()}
-						<span class="inline-block {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
+						<span class="inline-block {capital}"
 							>{crumb.tooltip ?? crumb.name}</span
 						>
 					{/snippet}
@@ -125,6 +126,7 @@
 {/snippet}
 
 {#snippet inner(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
+  {@const capital = crumb.capitalize === false ? '' : 'first-letter:capitalize'}
 	{#if crumb.icon}
 		{@const Icon = crumb.icon as Component}
 		<Icon class="size-4" {...crumb.data} />
@@ -132,16 +134,17 @@
 	{#if crumb.snippet}
 		{@render crumb.snippet(crumb)}
 	{:else if crumb.name}
-		<span class="max-w-28 truncate {crumb.capitalize === false ? '' : 'first-letter:capitalize'}">
+		<span class="max-w-28 truncate {capital}">
 			{crumb.name}
 		</span>
 	{/if}
 {/snippet}
 
 {#snippet link(crumb: Crumb | Omit<Crumb, 'dropdown'>)}
+  {@const capital = crumb.capitalize === false ? '' : 'first-letter:capitalize'}
 	<Sidebar.MenuButton data-active={crumb.href === page.url.pathname}>
 		{#snippet tooltipContent()}
-			<span class="inline-block {crumb.capitalize === false ? '' : 'first-letter:capitalize'}"
+			<span class="inline-block {capital}"
 				>{crumb.tooltip ?? crumb.name}</span
 			>
 		{/snippet}

--- a/src/lib/hooks/breadcrumb.svelte.ts
+++ b/src/lib/hooks/breadcrumb.svelte.ts
@@ -3,7 +3,7 @@ import { getContext, setContext, untrack, type Component, type Snippet } from 's
 import Home from 'lucide-svelte/icons/home';
 
 interface CrumbBase {
-	name: string;
+	name?: string;
 	capitalize?: boolean;
 	href?: string;
 	icon?: Component | unknown;

--- a/src/lib/hooks/breadcrumb.svelte.ts
+++ b/src/lib/hooks/breadcrumb.svelte.ts
@@ -3,7 +3,7 @@ import { getContext, setContext, untrack, type Component, type Snippet } from 's
 import Home from 'lucide-svelte/icons/home';
 
 interface CrumbBase {
-	name?: string;
+	name: string;
 	capitalize?: boolean;
 	href?: string;
 	icon?: Component | unknown;

--- a/src/lib/hooks/breadcrumb.svelte.ts
+++ b/src/lib/hooks/breadcrumb.svelte.ts
@@ -4,6 +4,7 @@ import Home from 'lucide-svelte/icons/home';
 
 interface CrumbBase {
 	name?: string;
+	capitalize?: boolean;
 	href?: string;
 	icon?: Component | unknown;
 	snippet?: Snippet;

--- a/src/routes/@[id=id]/[[profile]]/nav-crumbs.svelte
+++ b/src/routes/@[id=id]/[[profile]]/nav-crumbs.svelte
@@ -110,6 +110,7 @@
 		{
 			icon: PlayerHead,
 			name: account?.name,
+			capitalize: false,
 			href: `/@${account?.name}`,
 			tooltip: 'Player',
 			data: {
@@ -117,6 +118,7 @@
 			},
 			dropdown: otherMembers?.map((m) => ({
 				name: m.username,
+				capitalize: false,
 				href: `/@${m.uuid}/${profile?.profileId}`,
 				data: {
 					uuid: m.uuid,


### PR DESCRIPTION
fixes the unnecessary capitalization of everything in the sidebar, everything is capitalized by default now, but youre able to specifically specify to keep the original text

### Before
![chrome_lXQntjAImU](https://github.com/user-attachments/assets/4b8f554c-c191-49bf-bece-0efa4037a6a8)
### After
![chrome_mSY9LpXUPl](https://github.com/user-attachments/assets/795f4785-bd41-4745-9fa6-941a4a0ace42)
(no it doesnt make them all lowercase thats just how sage's names are)