### PR TITLE
Add team management options to event admin page

### DIFF
--- a/src/components/copy-to-clipboard.svelte
+++ b/src/components/copy-to-clipboard.svelte
@@ -6,7 +6,7 @@
 
 	let copyPromise: Promise<void> | null = $state(null);
 
-	function copy() {
+	function copyClicked() {
 		copyPromise = navigator.clipboard
 			.writeText(text)
 			.then((x) => new Promise((resolve) => setTimeout(() => resolve(x), 100)));
@@ -20,9 +20,19 @@
 		text?: string;
 		size?: 'default' | 'sm' | 'lg' | 'icon' | undefined;
 		class?: string | undefined | null;
+		iconClass?: string;
+		copy?: () => void;
 	}
 
-	let { text = '', size = undefined, class: className = undefined, ...rest }: Props = $props();
+	let {
+		text = '',
+		size = undefined,
+		class: className = undefined,
+		iconClass = '',
+		children,
+		copy = $bindable(copyClicked),
+		...rest
+	}: Props = $props();
 
 	let iconSize = $state(20);
 
@@ -32,16 +42,17 @@
 	});
 </script>
 
-<Button variant="link" onclick={copy} {size} class={className} {...rest}>
+<Button variant="ghost" onclick={copyClicked} {size} class={className} {...rest}>
 	{#if copyPromise}
 		{#await copyPromise}
-			<LoaderCircle class="animate-spin" size={iconSize} />
+			<LoaderCircle class="animate-spin {iconClass}" size={iconSize} />
 		{:then}
-			<Check size={iconSize} />
+			<Check size={iconSize} class={iconClass} />
 		{:catch}
-			<Copy size={iconSize} />
+			<Copy size={iconSize} class={iconClass} />
 		{/await}
 	{:else}
-		<Copy size={iconSize} />
+		<Copy size={iconSize} class={iconClass} />
 	{/if}
+	{@render children?.()}
 </Button>

--- a/src/components/events/team-name-selector.svelte
+++ b/src/components/events/team-name-selector.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	import { Button } from '$ui/button';
+	import RefreshCcw from 'lucide-svelte/icons/refresh-ccw';
+	import ComboBox from '$comp/ui/combobox/combo-box.svelte';
+	import type { components } from '$lib/api/api';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		words?: components['schemas']['EventTeamsWordListDto'];
+		loading?: boolean;
+		selected?: string[];
+		displayName?: string;
+	}
+
+	let {
+		words = { first: [], second: [], third: [] } as components['schemas']['EventTeamsWordListDto'],
+		loading = $bindable(false),
+		selected = $bindable([]),
+		displayName = $bindable(''),
+	}: Props = $props();
+
+	let picked1 = $state('');
+	let picked2 = $state('');
+	let picked3 = $state('');
+
+	function generateTeamName() {
+		const firstWords = words?.first ?? [];
+		const secondWords = words?.second ?? [];
+		const thirdWords = words?.third ?? [];
+
+		const first = firstWords[Math.floor(Math.random() * firstWords.length)].replaceAll(' ', '_');
+		const second = secondWords[Math.floor(Math.random() * secondWords.length)].replaceAll(' ', '_');
+		const third = thirdWords[Math.floor(Math.random() * thirdWords.length)].replaceAll(' ', '_');
+
+		if (Math.random() > 0.5) {
+			picked1 = first;
+			picked3 = '';
+
+			if (Math.random() > 0.5) {
+				picked2 = second;
+			} else {
+				picked2 = third;
+			}
+		} else {
+			picked1 = first;
+			picked2 = second;
+			picked3 = third;
+		}
+
+		updateName();
+
+		if (name.length > 32) {
+			generateTeamName();
+		}
+	}
+
+	function updateName() {
+		name = (picked1 ?? '') + ' ' + (picked2 ?? '') + ' ' + (picked3 ?? '').trim();
+		displayName = name.replaceAll('_', ' ');
+	}
+
+	let name = $state('');
+
+	let wordOptions = $derived(
+		Array.from(new Set([...(words?.first ?? []), ...(words?.second ?? []), ...(words?.third ?? [])]), (w) => ({
+			value: w.replaceAll(' ', '_'),
+			label: w,
+		}))
+	);
+
+	onMount(() => {
+		if (selected.length > 0) {
+			picked1 = selected[0] ?? '';
+			picked2 = selected[1] ?? '';
+			picked3 = selected[2] ?? '';
+		} else {
+			generateTeamName();
+		}
+	});
+</script>
+
+<input type="hidden" name="name" value={name} hidden />
+<div class="flex flex-col gap-2">
+	<p class="text-xl font-semibold">{name.replaceAll('_', ' ')}</p>
+	<div class="flex max-w-sm flex-row flex-wrap gap-1 lg:flex-nowrap">
+		<Button variant="secondary" onclick={generateTeamName} disabled={loading} class="order-5 lg:order-1">
+			<RefreshCcw />
+		</Button>
+		<ComboBox
+			options={wordOptions}
+			bind:value={picked1}
+			exclude={[picked2, picked3]}
+			onChange={updateName}
+			placeholder="Select Word"
+			btnClass="order-2"
+		/>
+		<ComboBox
+			options={wordOptions}
+			bind:value={picked2}
+			exclude={[picked1, picked3]}
+			onChange={updateName}
+			placeholder="Select Word"
+			btnClass="order-3"
+		/>
+		<ComboBox
+			options={wordOptions}
+			bind:value={picked3}
+			exclude={[picked1, picked2]}
+			onChange={updateName}
+			placeholder="Select Word"
+			clear={true}
+			btnClass="order-4"
+		/>
+	</div>
+</div>

--- a/src/components/ui/popover/popover-mobile.svelte
+++ b/src/components/ui/popover/popover-mobile.svelte
@@ -29,6 +29,7 @@
 		triggerRootClass?: string;
 		class?: string;
 		trigger?: import('svelte').Snippet;
+		child?: import('svelte').Snippet<[{ props: Record<string, unknown> }]>;
 		children?: import('svelte').Snippet;
 	}
 
@@ -40,6 +41,7 @@
 		class: className = undefined,
 		trigger,
 		children,
+		child: triggerChild,
 		hasContent = true,
 	}: Props = $props();
 </script>
@@ -47,7 +49,15 @@
 <Root bind:open>
 	<div onmouseenter={mouseEnter} onmouseleave={mouseLeave} role="contentinfo" class={triggerRootClass}>
 		<Trigger class={triggerClass}>
-			{@render trigger?.()}
+			{#snippet child(data)}
+				{#if triggerChild}
+					{@render triggerChild?.(data)}
+				{:else}
+					<button {...data.props}>
+						{@render trigger?.()}
+					</button>
+				{/if}
+			{/snippet}
 		</Trigger>
 	</div>
 	{#if children?.length && hasContent}

--- a/src/components/ui/tooltip/tooltip-simple.svelte
+++ b/src/components/ui/tooltip/tooltip-simple.svelte
@@ -8,16 +8,21 @@
 		class: className,
 		sideOffset = 4,
 		trigger,
+		child: triggerChild,
 		...restProps
 	}: TooltipPrimitive.ContentProps & {
-		trigger: Snippet;
+		trigger?: Snippet;
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
 	} = $props();
 </script>
 
 <TooltipPrimitive.Provider>
 	<TooltipPrimitive.Root delayDuration={0}>
 		<TooltipPrimitive.Trigger>
-			{@render trigger()}
+			{#snippet child(data)}
+				{@render triggerChild?.(data)}
+			{/snippet}
+			{@render trigger?.()}
 		</TooltipPrimitive.Trigger>
 		<TooltipPrimitive.Content
 			bind:ref

--- a/src/components/visible-toggle.svelte
+++ b/src/components/visible-toggle.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import Button, { type ButtonProps } from '$ui/button/button.svelte';
+	import Eye from 'lucide-svelte/icons/eye';
+	import EyeOff from 'lucide-svelte/icons/eye-off';
+
+	interface Props extends ButtonProps {
+		visible: boolean;
+	}
+	let { visible = $bindable(false), ...rest }: Props = $props();
+</script>
+
+<Button
+	class="h-8 w-8"
+	variant="ghost"
+	onclick={() => (visible = !visible)}
+	aria-label={visible ? 'Hide' : 'Show'}
+	{...rest}
+>
+	{#if visible}
+		<Eye class="h-4 w-4" />
+	{:else}
+		<EyeOff class="h-4 w-4" />
+	{/if}
+</Button>

--- a/src/lib/api/api.d.ts
+++ b/src/lib/api/api.d.ts
@@ -302,6 +302,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/link-account": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Link an Account */
+        post: operations["EliteAPIFeaturesAdminLinkAccountLinkAccountEndpoint"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/guild/{guildId}/refresh": {
         parameters: {
             query?: never;
@@ -316,6 +333,23 @@ export interface paths {
          * @description This fetches the latest data from Discord for the specified guild
          */
         post: operations["EliteAPIFeaturesAdminRefreshDiscordGuildRefreshDiscordGuildEndpoint"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/unlink-account": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Unlink an Account */
+        post: operations["EliteAPIFeaturesAdminUnlinkAccountUnlinkAccountEndpoint"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1075,7 +1109,8 @@ export interface paths {
         delete: operations["EliteAPIFeaturesEventsAdminDeleteTeamDeleteTeamEndpoint"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update a team */
+        patch: operations["EliteAPIFeaturesEventsAdminUpdateTeamUpdateTeamEndpoint"];
         trace?: never;
     };
     "/guild/{discordId}/event/{eventId}/bans": {
@@ -1156,6 +1191,23 @@ export interface paths {
         /** Get event teams */
         get: operations["EliteAPIFeaturesEventsAdminGetTeamsGetTeamsEndpoint"];
         put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/guild/{discordId}/events/{eventId}/teams/{teamId}/owner": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Set player as team owner */
+        put: operations["EliteAPIFeaturesEventsAdminSetTeamOwnerSetTeamOwnerEndpoint"];
         post?: never;
         delete?: never;
         options?: never;
@@ -1390,6 +1442,23 @@ export interface paths {
         put?: never;
         /** Leave a team */
         post: operations["EliteAPIFeaturesEventsUserLeaveTeamLeaveTeamEndpoint"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/event/{eventId}/team/{teamId}/owner": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Set player as team owner */
+        put: operations["EliteAPIFeaturesEventsUserSetTeamOwnerSetTeamOwnerEndpoint"];
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2637,14 +2706,20 @@ export interface components {
             youtube?: string | null;
         };
         PlayerRequest: Record<string, never>;
+        /** @description the dto used to send an error response to the client */
         ErrorResponse: {
             /**
              * Format: int32
+             * @description the http status code sent to the client. default is 400.
              * @default 400
              */
             statusCode: number;
-            /** @default One or more errors occurred! */
+            /**
+             * @description the message for the error response
+             * @default One or more errors occurred!
+             */
             message: string;
+            /** @description the collection of errors for the current context */
             errors: {
                 [key: string]: string[];
             };
@@ -2852,7 +2927,15 @@ export interface components {
             discriminator?: string | null;
             avatar?: string | null;
         };
+        AdminLinkAccountRequest: {
+            discordId: string;
+            player: string;
+        };
         GuildIdRequest: Record<string, never>;
+        AdminUnlinkAccountRequest: {
+            discordId: string;
+            player: string;
+        };
         AuthSessionDto: {
             /** @description Discord user ID */
             id: string;
@@ -3224,6 +3307,8 @@ export interface components {
             data?: unknown;
             /** Format: int32 */
             id: number;
+            accountId?: string | null;
+            notes?: string | null;
         };
         /** @enum {integer} */
         EventMemberStatus: 0 | 1 | 2 | 3;
@@ -3488,11 +3573,15 @@ export interface components {
         };
         GetTeamsRequest: Record<string, never>;
         KickTeamMemberRequest: Record<string, never>;
-        UnbanMemberRequest: Record<string, never>;
+        SetTeamOwnerRequest: {
+            /** @description Player uuid or ign */
+            player: string;
+        };
         EditEventBannerDto: {
             /** Format: binary */
             image?: string | null;
         };
+        UnbanMemberRequest: Record<string, never>;
         GetEventRequest: Record<string, never>;
         EditEventDto: {
             name?: string | null;
@@ -3515,6 +3604,13 @@ export interface components {
             medalData?: components["schemas"]["MedalEventData"] | null;
             pestData?: components["schemas"]["PestEventData"] | null;
             collectionData?: components["schemas"]["CollectionEventData"] | null;
+        };
+        UpdateEventTeamDto: {
+            /** @description An array of strings for the team name, example: [ "Bountiful", "Farmers" ] */
+            name?: string[] | null;
+            color?: string | null;
+            /** @description If join code should be changed */
+            changeCode?: boolean | null;
         };
         EventDefaultsDto: {
             cropWeights: {
@@ -3553,12 +3649,11 @@ export interface components {
         KickTeamMemberRequest2: Record<string, never>;
         LeaveEventRequest: Record<string, never>;
         LeaveTeamRequest: Record<string, never>;
-        UpdateTeamJoinCodeRequest: Record<string, never>;
-        UpdateEventTeamDto: {
-            /** @description An array of strings for the team name, example: [ "Bountiful", "Farmers" ] */
-            name?: string[] | null;
-            color?: string | null;
+        ChangeTeamOwnerRequest: {
+            /** @description Player uuid or ign */
+            player: string;
         };
+        UpdateTeamJoinCodeRequest: Record<string, never>;
         GardenDto: {
             /** @description Profile ID */
             profileId: string;
@@ -5275,6 +5370,42 @@ export interface operations {
             };
         };
     };
+    EliteAPIFeaturesAdminLinkAccountLinkAccountEndpoint: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AdminLinkAccountRequest"];
+            };
+        };
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     EliteAPIFeaturesAdminRefreshDiscordGuildRefreshDiscordGuildEndpoint: {
         parameters: {
             query?: never;
@@ -5301,6 +5432,42 @@ export interface operations {
                 content: {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    EliteAPIFeaturesAdminUnlinkAccountUnlinkAccountEndpoint: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AdminUnlinkAccountRequest"];
+            };
+        };
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Unauthorized */
             401: {
@@ -7279,6 +7446,49 @@ export interface operations {
             };
         };
     };
+    EliteAPIFeaturesEventsAdminUpdateTeamUpdateTeamEndpoint: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Discord Snowflake ID of the requested resource (guild, user, etc.) */
+                discordId: number;
+                eventId: number;
+                teamId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateEventTeamDto"];
+            };
+        };
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     EliteAPIFeaturesEventsAdminGetBannedMembersGetBannedMembersEndpoint: {
         parameters: {
             query?: never;
@@ -7458,6 +7668,49 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["EventTeamWithMembersDto"][];
                 };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    EliteAPIFeaturesEventsAdminSetTeamOwnerSetTeamOwnerEndpoint: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Discord Snowflake ID of the requested resource (guild, user, etc.) */
+                discordId: number;
+                eventId: number;
+                teamId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetTeamOwnerRequest"];
+            };
+        };
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Bad Request */
             400: {
@@ -7905,6 +8158,47 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    EliteAPIFeaturesEventsUserSetTeamOwnerSetTeamOwnerEndpoint: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                eventId: number;
+                teamId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangeTeamOwnerRequest"];
+            };
+        };
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
             };
             /** @description Unauthorized */
             401: {

--- a/src/lib/api/api.d.ts
+++ b/src/lib/api/api.d.ts
@@ -3574,7 +3574,6 @@ export interface components {
         GetTeamsRequest: Record<string, never>;
         KickTeamMemberRequest: Record<string, never>;
         SetTeamOwnerRequest: {
-            /** @description Player uuid or ign */
             player: string;
         };
         EditEventBannerDto: {
@@ -3650,7 +3649,6 @@ export interface components {
         LeaveEventRequest: Record<string, never>;
         LeaveTeamRequest: Record<string, never>;
         ChangeTeamOwnerRequest: {
-            /** @description Player uuid or ign */
             player: string;
         };
         UpdateTeamJoinCodeRequest: Record<string, never>;
@@ -7124,7 +7122,9 @@ export interface operations {
     };
     EliteAPIFeaturesEventsAdminCreateTeamCreateTeamEndpoint: {
         parameters: {
-            query?: never;
+            query?: {
+                userId?: string | null;
+            };
             header?: never;
             path: {
                 /** @description Discord Snowflake ID of the requested resource (guild, user, etc.) */
@@ -7692,7 +7692,6 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description Discord Snowflake ID of the requested resource (guild, user, etc.) */
                 discordId: number;
                 eventId: number;
                 teamId: number;
@@ -7711,15 +7710,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
             };
             /** @description Unauthorized */
             401: {
@@ -8180,7 +8170,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ChangeTeamOwnerRequest"];
+                "*/*": components["schemas"]["ChangeTeamOwnerRequest"];
             };
         };
         responses: {
@@ -8190,15 +8180,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
             };
             /** @description Unauthorized */
             401: {

--- a/src/lib/api/elite.ts
+++ b/src/lib/api/elite.ts
@@ -1092,6 +1092,25 @@ export const KickEventTeamMember = async (
 		},
 	});
 
+export const TransferEventTeamOwnership = async (
+	accessToken: string,
+	data: { eventId: string; teamId: string; playerUuid: string }
+) =>
+	await PUT('/event/{eventId}/team/{teamId}/owner', {
+		params: {
+			path: {
+				eventId: data.eventId as unknown as number,
+				teamId: data.teamId as unknown as number,
+			},
+		},
+		body: {
+			player: data.playerUuid,
+		},
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+		},
+	});
+
 export const GetProducts = async () => await GET('/products', {});
 
 export const GetAdminProducts = async (token: string) =>

--- a/src/lib/api/elite.ts
+++ b/src/lib/api/elite.ts
@@ -754,6 +754,41 @@ export const BanEventMember = async (
 		},
 	});
 
+export const AdminKickTeamMember = async (
+	accessToken: string,
+	discordId: string,
+	eventId: string,
+	playerUuid: string,
+	teamId: string
+) =>
+	await DELETE('/guild/{discordId}/events/{eventId}/teams/{teamId}/members/{player}', {
+		params: {
+			path: {
+				discordId: discordId as unknown as number,
+				eventId: eventId as unknown as number,
+				player: playerUuid,
+				teamId: teamId as unknown as number,
+			},
+		},
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+		},
+	});
+
+export const AdminDeleteTeam = async (accessToken: string, discordId: string, eventId: string, teamId: string) =>
+	await DELETE('/guild/{discordId}/events/{eventId}/teams/{teamId}', {
+		params: {
+			path: {
+				discordId: discordId as unknown as number,
+				eventId: eventId as unknown as number,
+				teamId: teamId as unknown as number,
+			},
+		},
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+		},
+	});
+
 export const UnbanEventMember = async (accessToken: string, discordId: string, eventId: string, playerUuid: string) =>
 	await DELETE('/guild/{discordId}/events/{eventId}/bans/{playerUuid}', {
 		params: {
@@ -1106,6 +1141,70 @@ export const TransferEventTeamOwnership = async (
 		body: {
 			player: data.playerUuid,
 		},
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+		},
+	});
+
+export const AdminTransferEventTeamOwnership = async (
+	accessToken: string,
+	data: { guildId: string; eventId: string; teamId: string; playerUuid: string }
+) =>
+	await PUT('/guild/{discordId}/events/{eventId}/teams/{teamId}/owner', {
+		params: {
+			path: {
+				discordId: data.guildId as unknown as number,
+				eventId: data.eventId as unknown as number,
+				teamId: data.teamId as unknown as number,
+			},
+		},
+		body: {
+			player: data.playerUuid,
+		},
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+		},
+	});
+
+export const AddMemberToTeam = async (
+	accessToken: string,
+	discordId: string,
+	eventId: string,
+	teamId: string,
+	playerUuid: string
+) =>
+	await POST('/guild/{discordId}/events/{eventId}/teams/{teamId}/members/{player}', {
+		params: {
+			path: {
+				discordId: discordId as unknown as number,
+				eventId: eventId as unknown as number,
+				teamId: teamId as unknown as number,
+				player: playerUuid,
+			},
+		},
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+		},
+	});
+
+export const AdminCreateEventTeam = async (
+	accessToken: string,
+	discordId: string,
+	eventId: string,
+	userId: string,
+	team: components['schemas']['CreateEventTeamDto']
+) =>
+	await POST('/guild/{discordId}/events/{eventId}/teams', {
+		params: {
+			path: {
+				discordId: discordId as unknown as number,
+				eventId: eventId as unknown as number,
+			},
+			query: {
+				userId: userId,
+			},
+		},
+		body: team,
 		headers: {
 			Authorization: `Bearer ${accessToken}`,
 		},

--- a/src/lib/api/swagger.json
+++ b/src/lib/api/swagger.json
@@ -851,6 +851,44 @@
 		  ]
 		}
 	  },
+	  "/admin/link-account": {
+		"post": {
+		  "tags": [
+			"Admin"
+		  ],
+		  "summary": "Link an Account",
+		  "operationId": "EliteAPIFeaturesAdminLinkAccountLinkAccountEndpoint",
+		  "requestBody": {
+			"x-name": "AdminLinkAccountRequest",
+			"description": "",
+			"content": {
+			  "application/json": {
+				"schema": {
+				  "$ref": "#/components/schemas/AdminLinkAccountRequest"
+				}
+			  }
+			},
+			"required": true,
+			"x-position": 1
+		  },
+		  "responses": {
+			"204": {
+			  "description": "No Content"
+			},
+			"401": {
+			  "description": "Unauthorized"
+			},
+			"403": {
+			  "description": "Forbidden"
+			}
+		  },
+		  "security": [
+			{
+			  "JWTBearerAuth": []
+			}
+		  ]
+		}
+	  },
 	  "/admin/guild/{guildId}/refresh": {
 		"post": {
 		  "tags": [
@@ -883,6 +921,44 @@
 				  }
 				}
 			  }
+			},
+			"401": {
+			  "description": "Unauthorized"
+			},
+			"403": {
+			  "description": "Forbidden"
+			}
+		  },
+		  "security": [
+			{
+			  "JWTBearerAuth": []
+			}
+		  ]
+		}
+	  },
+	  "/admin/unlink-account": {
+		"post": {
+		  "tags": [
+			"Admin"
+		  ],
+		  "summary": "Unlink an Account",
+		  "operationId": "EliteAPIFeaturesAdminUnlinkAccountUnlinkAccountEndpoint",
+		  "requestBody": {
+			"x-name": "AdminUnlinkAccountRequest",
+			"description": "",
+			"content": {
+			  "application/json": {
+				"schema": {
+				  "$ref": "#/components/schemas/AdminUnlinkAccountRequest"
+				}
+			  }
+			},
+			"required": true,
+			"x-position": 1
+		  },
+		  "responses": {
+			"204": {
+			  "description": "No Content"
 			},
 			"401": {
 			  "description": "Unauthorized"
@@ -3743,6 +3819,77 @@
 			  "JWTBearerAuth": []
 			}
 		  ]
+		},
+		"patch": {
+		  "tags": [
+			"Guild"
+		  ],
+		  "summary": "Update a team",
+		  "operationId": "EliteAPIFeaturesEventsAdminUpdateTeamUpdateTeamEndpoint",
+		  "parameters": [
+			{
+			  "name": "discordId",
+			  "in": "path",
+			  "required": true,
+			  "description": "Discord Snowflake ID of the requested resource (guild, user, etc.)",
+			  "schema": {
+				"type": "integer",
+				"format": "int64"
+			  }
+			},
+			{
+			  "name": "eventId",
+			  "in": "path",
+			  "required": true,
+			  "schema": {
+				"type": "integer",
+				"format": "uint64"
+			  }
+			},
+			{
+			  "name": "teamId",
+			  "in": "path",
+			  "required": true,
+			  "schema": {
+				"type": "integer",
+				"format": "int32"
+			  }
+			}
+		  ],
+		  "requestBody": {
+			"x-name": "team",
+			"content": {
+			  "application/json": {
+				"schema": {
+				  "$ref": "#/components/schemas/UpdateEventTeamDto"
+				}
+			  }
+			},
+			"required": true
+		  },
+		  "responses": {
+			"204": {
+			  "description": "No Content"
+			},
+			"400": {
+			  "description": "Bad Request",
+			  "content": {
+				"application/problem+json": {
+				  "schema": {
+					"$ref": "#/components/schemas/ErrorResponse"
+				  }
+				}
+			  }
+			},
+			"401": {
+			  "description": "Unauthorized"
+			}
+		  },
+		  "security": [
+			{
+			  "JWTBearerAuth": []
+			}
+		  ]
 		}
 	  },
 	  "/guild/{discordId}/event/{eventId}/bans": {
@@ -4025,6 +4172,81 @@
 				  }
 				}
 			  }
+			},
+			"400": {
+			  "description": "Bad Request",
+			  "content": {
+				"application/problem+json": {
+				  "schema": {
+					"$ref": "#/components/schemas/ErrorResponse"
+				  }
+				}
+			  }
+			},
+			"401": {
+			  "description": "Unauthorized"
+			}
+		  },
+		  "security": [
+			{
+			  "JWTBearerAuth": []
+			}
+		  ]
+		}
+	  },
+	  "/guild/{discordId}/events/{eventId}/teams/{teamId}/owner": {
+		"put": {
+		  "tags": [
+			"Guild"
+		  ],
+		  "summary": "Set player as team owner",
+		  "operationId": "EliteAPIFeaturesEventsAdminSetTeamOwnerSetTeamOwnerEndpoint",
+		  "parameters": [
+			{
+			  "name": "discordId",
+			  "in": "path",
+			  "required": true,
+			  "description": "Discord Snowflake ID of the requested resource (guild, user, etc.)",
+			  "schema": {
+				"type": "integer",
+				"format": "int64"
+			  }
+			},
+			{
+			  "name": "eventId",
+			  "in": "path",
+			  "required": true,
+			  "schema": {
+				"type": "integer",
+				"format": "uint64"
+			  }
+			},
+			{
+			  "name": "teamId",
+			  "in": "path",
+			  "required": true,
+			  "schema": {
+				"type": "integer",
+				"format": "int32"
+			  }
+			}
+		  ],
+		  "requestBody": {
+			"x-name": "SetTeamOwnerRequest",
+			"description": "",
+			"content": {
+			  "application/json": {
+				"schema": {
+				  "$ref": "#/components/schemas/SetTeamOwnerRequest"
+				}
+			  }
+			},
+			"required": true,
+			"x-position": 1
+		  },
+		  "responses": {
+			"204": {
+			  "description": "No Content"
 			},
 			"400": {
 			  "description": "Bad Request",
@@ -4679,6 +4901,71 @@
 		  "responses": {
 			"204": {
 			  "description": "No Content"
+			},
+			"401": {
+			  "description": "Unauthorized"
+			}
+		  },
+		  "security": [
+			{
+			  "JWTBearerAuth": []
+			}
+		  ]
+		}
+	  },
+	  "/event/{eventId}/team/{teamId}/owner": {
+		"put": {
+		  "tags": [
+			"Event"
+		  ],
+		  "summary": "Set player as team owner",
+		  "operationId": "EliteAPIFeaturesEventsUserSetTeamOwnerSetTeamOwnerEndpoint",
+		  "parameters": [
+			{
+			  "name": "eventId",
+			  "in": "path",
+			  "required": true,
+			  "schema": {
+				"type": "integer",
+				"format": "uint64"
+			  }
+			},
+			{
+			  "name": "teamId",
+			  "in": "path",
+			  "required": true,
+			  "schema": {
+				"type": "integer",
+				"format": "int32"
+			  }
+			}
+		  ],
+		  "requestBody": {
+			"x-name": "ChangeTeamOwnerRequest",
+			"description": "",
+			"content": {
+			  "application/json": {
+				"schema": {
+				  "$ref": "#/components/schemas/ChangeTeamOwnerRequest"
+				}
+			  }
+			},
+			"required": true,
+			"x-position": 1
+		  },
+		  "responses": {
+			"204": {
+			  "description": "No Content"
+			},
+			"400": {
+			  "description": "Bad Request",
+			  "content": {
+				"application/problem+json": {
+				  "schema": {
+					"$ref": "#/components/schemas/ErrorResponse"
+				  }
+				}
+			  }
 			},
 			"401": {
 			  "description": "Unauthorized"
@@ -8921,6 +9208,7 @@
 		},
 		"ErrorResponse": {
 		  "type": "object",
+		  "description": "the dto used to send an error response to the client",
 		  "additionalProperties": false,
 		  "required": [
 			"statusCode",
@@ -8930,15 +9218,18 @@
 		  "properties": {
 			"statusCode": {
 			  "type": "integer",
+			  "description": "the http status code sent to the client. default is 400.",
 			  "format": "int32",
 			  "default": 400
 			},
 			"message": {
 			  "type": "string",
+			  "description": "the message for the error response",
 			  "default": "One or more errors occurred!"
 			},
 			"errors": {
 			  "type": "object",
+			  "description": "the collection of errors for the current context",
 			  "additionalProperties": {
 				"type": "array",
 				"items": {
@@ -9556,9 +9847,41 @@
 			}
 		  }
 		},
+		"AdminLinkAccountRequest": {
+		  "type": "object",
+		  "additionalProperties": false,
+		  "required": [
+			"discordId",
+			"player"
+		  ],
+		  "properties": {
+			"discordId": {
+			  "type": "string"
+			},
+			"player": {
+			  "type": "string"
+			}
+		  }
+		},
 		"GuildIdRequest": {
 		  "type": "object",
 		  "additionalProperties": false
+		},
+		"AdminUnlinkAccountRequest": {
+		  "type": "object",
+		  "additionalProperties": false,
+		  "required": [
+			"discordId",
+			"player"
+		  ],
+		  "properties": {
+			"discordId": {
+			  "type": "string"
+			},
+			"player": {
+			  "type": "string"
+			}
+		  }
 		},
 		"AuthSessionDto": {
 		  "type": "object",
@@ -10988,6 +11311,15 @@
 			"id": {
 			  "type": "integer",
 			  "format": "int32"
+			},
+			"accountId": {
+			  "type": "string",
+			  "nullable": true
+			},
+			"notes": {
+			  "type": "string",
+			  "maxLength": 128,
+			  "nullable": true
 			}
 		  }
 		},
@@ -11755,9 +12087,20 @@
 		  "type": "object",
 		  "additionalProperties": false
 		},
-		"UnbanMemberRequest": {
+		"SetTeamOwnerRequest": {
 		  "type": "object",
-		  "additionalProperties": false
+		  "additionalProperties": false,
+		  "required": [
+			"player"
+		  ],
+		  "properties": {
+			"player": {
+			  "type": "string",
+			  "description": "Player uuid or ign",
+			  "minLength": 1,
+			  "nullable": false
+			}
+		  }
 		},
 		"EditEventBannerDto": {
 		  "type": "object",
@@ -11769,6 +12112,10 @@
 			  "nullable": true
 			}
 		  }
+		},
+		"UnbanMemberRequest": {
+		  "type": "object",
+		  "additionalProperties": false
 		},
 		"GetEventRequest": {
 		  "type": "object",
@@ -11864,6 +12211,32 @@
 				  "$ref": "#/components/schemas/CollectionEventData"
 				}
 			  ]
+			}
+		  }
+		},
+		"UpdateEventTeamDto": {
+		  "type": "object",
+		  "additionalProperties": false,
+		  "properties": {
+			"name": {
+			  "type": "array",
+			  "description": "An array of strings for the team name, example: [ \"Bountiful\", \"Farmers\" ]",
+			  "maxItems": 3,
+			  "minItems": 1,
+			  "nullable": true,
+			  "items": {
+				"type": "string"
+			  }
+			},
+			"color": {
+			  "type": "string",
+			  "maxLength": 7,
+			  "nullable": true
+			},
+			"changeCode": {
+			  "type": "boolean",
+			  "description": "If join code should be changed",
+			  "nullable": true
 			}
 		  }
 		},
@@ -12020,30 +12393,24 @@
 		  "type": "object",
 		  "additionalProperties": false
 		},
+		"ChangeTeamOwnerRequest": {
+		  "type": "object",
+		  "additionalProperties": false,
+		  "required": [
+			"player"
+		  ],
+		  "properties": {
+			"player": {
+			  "type": "string",
+			  "description": "Player uuid or ign",
+			  "minLength": 1,
+			  "nullable": false
+			}
+		  }
+		},
 		"UpdateTeamJoinCodeRequest": {
 		  "type": "object",
 		  "additionalProperties": false
-		},
-		"UpdateEventTeamDto": {
-		  "type": "object",
-		  "additionalProperties": false,
-		  "properties": {
-			"name": {
-			  "type": "array",
-			  "description": "An array of strings for the team name, example: [ \"Bountiful\", \"Farmers\" ]",
-			  "maxItems": 3,
-			  "minItems": 1,
-			  "nullable": true,
-			  "items": {
-				"type": "string"
-			  }
-			},
-			"color": {
-			  "type": "string",
-			  "maxLength": 7,
-			  "nullable": true
-			}
-		  }
 		},
 		"GardenDto": {
 		  "type": "object",

--- a/src/lib/api/swagger.json
+++ b/src/lib/api/swagger.json
@@ -3340,6 +3340,14 @@
 				"type": "integer",
 				"format": "uint64"
 			  }
+			},
+			{
+			  "name": "userId",
+			  "in": "query",
+			  "schema": {
+				"type": "string",
+				"nullable": true
+			  }
 			}
 		  ],
 		  "requestBody": {
@@ -4206,10 +4214,9 @@
 			  "name": "discordId",
 			  "in": "path",
 			  "required": true,
-			  "description": "Discord Snowflake ID of the requested resource (guild, user, etc.)",
 			  "schema": {
 				"type": "integer",
-				"format": "int64"
+				"format": "uint64"
 			  }
 			},
 			{
@@ -4247,16 +4254,6 @@
 		  "responses": {
 			"204": {
 			  "description": "No Content"
-			},
-			"400": {
-			  "description": "Bad Request",
-			  "content": {
-				"application/problem+json": {
-				  "schema": {
-					"$ref": "#/components/schemas/ErrorResponse"
-				  }
-				}
-			  }
 			},
 			"401": {
 			  "description": "Unauthorized"
@@ -4944,7 +4941,7 @@
 			"x-name": "ChangeTeamOwnerRequest",
 			"description": "",
 			"content": {
-			  "application/json": {
+			  "*/*": {
 				"schema": {
 				  "$ref": "#/components/schemas/ChangeTeamOwnerRequest"
 				}
@@ -4956,16 +4953,6 @@
 		  "responses": {
 			"204": {
 			  "description": "No Content"
-			},
-			"400": {
-			  "description": "Bad Request",
-			  "content": {
-				"application/problem+json": {
-				  "schema": {
-					"$ref": "#/components/schemas/ErrorResponse"
-				  }
-				}
-			  }
 			},
 			"401": {
 			  "description": "Unauthorized"
@@ -12095,10 +12082,7 @@
 		  ],
 		  "properties": {
 			"player": {
-			  "type": "string",
-			  "description": "Player uuid or ign",
-			  "minLength": 1,
-			  "nullable": false
+			  "type": "string"
 			}
 		  }
 		},
@@ -12401,10 +12385,7 @@
 		  ],
 		  "properties": {
 			"player": {
-			  "type": "string",
-			  "description": "Player uuid or ign",
-			  "minLength": 1,
-			  "nullable": false
+			  "type": "string"
 			}
 		  }
 		},

--- a/src/routes/(auth)/admin/+page.svelte
+++ b/src/routes/(auth)/admin/+page.svelte
@@ -55,13 +55,14 @@
 							{/each}
 						</div>
 						<Tooltip.Simple>
-							{#snippet trigger()}
+							{#snippet child({ props })}
 								<Button
 									class="max-h-12"
 									onclick={() => {
 										manageMemberModal = true;
 										selectedMemberId = user.id ?? '';
 									}}
+									{...props}
 								>
 									<Settings size={16} />
 								</Button>

--- a/src/routes/(auth)/admin/actions/+page.server.ts
+++ b/src/routes/(auth)/admin/actions/+page.server.ts
@@ -99,4 +99,58 @@ export const actions: Actions = {
 			success: true,
 		};
 	},
+	linkAccount: async ({ locals, request }) => {
+		const { access_token: token } = locals;
+
+		if (!token) {
+			return fail(401, { error: 'Unauthorized' });
+		}
+
+		const data = await request.formData();
+		const playerId = data.get('player') as string;
+		const discordId = data.get('discord') as string;
+
+		const { response, error: e } = await POST('/admin/link-account', {
+			body: {
+				discordId: discordId,
+				player: playerId,
+			},
+			headers: { Authorization: `Bearer ${token}` },
+		});
+
+		if (!response.ok) {
+			return fail(500, { error: e || 'Failed to link account' });
+		}
+
+		return {
+			success: true,
+		};
+	},
+	unlinkAccount: async ({ locals, request }) => {
+		const { access_token: token } = locals;
+
+		if (!token) {
+			return fail(401, { error: 'Unauthorized' });
+		}
+
+		const data = await request.formData();
+		const playerId = data.get('player') as string;
+		const discordId = data.get('discord') as string;
+
+		const { response, error: e } = await POST('/admin/unlink-account', {
+			body: {
+				discordId: discordId,
+				player: playerId,
+			},
+			headers: { Authorization: `Bearer ${token}` },
+		});
+
+		if (!response.ok) {
+			return fail(500, { error: e || 'Failed to unlink account' });
+		}
+
+		return {
+			success: true,
+		};
+	},
 };

--- a/src/routes/(auth)/admin/actions/+page.svelte
+++ b/src/routes/(auth)/admin/actions/+page.svelte
@@ -38,6 +38,24 @@
 					<Button type="submit">Fetch</Button>
 				</form>
 			</div>
+
+			<div class="flex max-w-sm flex-col justify-between gap-2 rounded-md border-2 bg-card p-4">
+				<p>Link an Account</p>
+				<form method="post" action="?/linkAccount" class="flex w-fit flex-row gap-2" use:enhance>
+					<Input name="player" placeholder="Player name/uuid" maxlength={64} required />
+					<Input name="discord" placeholder="Discord ID" maxlength={64} required />
+					<Button type="submit">Link</Button>
+				</form>
+			</div>
+
+			<div class="flex max-w-sm flex-col justify-between gap-2 rounded-md border-2 bg-card p-4">
+				<p>Unlink an Account</p>
+				<form method="post" action="?/unlinkAccount" class="flex w-fit flex-row gap-2" use:enhance>
+					<Input name="player" placeholder="Player name/uuid" maxlength={64} required />
+					<Input name="discord" placeholder="Discord ID" maxlength={64} required />
+					<Button type="submit" variant="destructive">Unlink</Button>
+				</form>
+			</div>
 		</div>
 	</section>
 </div>

--- a/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/+page.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/+page.svelte
@@ -23,6 +23,7 @@
 	import { getFavoritesContext } from '$lib/stores/favorites.svelte';
 	import { page } from '$app/state';
 	import MemberList from './member-list.svelte';
+	import TooltipSimple from '$ui/tooltip/tooltip-simple.svelte';
 
 	interface Props {
 		data: PageData;
@@ -93,9 +94,7 @@
 						{#if !event.approved}
 							<Popover.Mobile>
 								{#snippet trigger()}
-									<div>
-										<TriangleAlert class="mt-1.5 text-destructive" />
-									</div>
+									<TriangleAlert class="mt-1.5 text-destructive" />
 								{/snippet}
 								<div>
 									<p class="font-semibold">Pending approval!</p>
@@ -122,12 +121,13 @@
 					</div>
 				</div>
 				<div class="flex flex-col gap-2 p-4">
-					<Popover.Mobile>
-						{#snippet trigger()}
+					<TooltipSimple side="left">
+						{#snippet child({ props })}
 							<Button
 								onclick={() => {
 									clickOutsideModalEdit = true;
 								}}
+								{...props}
 							>
 								<Settings />
 							</Button>
@@ -135,14 +135,15 @@
 						<div>
 							<p>Edit Event</p>
 						</div>
-					</Popover.Mobile>
+					</TooltipSimple>
 
-					<Popover.Mobile>
-						{#snippet trigger()}
+					<TooltipSimple side="left">
+						{#snippet child({ props })}
 							<Button
 								onclick={() => {
 									clickOutsideModalEditImage = true;
 								}}
+								{...props}
 							>
 								<Image />
 							</Button>
@@ -150,21 +151,19 @@
 						<div>
 							<p>Edit Banner Image</p>
 						</div>
-					</Popover.Mobile>
+					</TooltipSimple>
 
 					{#if event.approved}
-						<Popover.Mobile>
-							{#snippet trigger()}
-								<div>
-									<Button href="/event/{event.id}" target="_blank">
-										<ExternalLink />
-									</Button>
-								</div>
+						<TooltipSimple side="left">
+							{#snippet child({ props })}
+								<Button href="/event/{event.id}" target="_blank" {...props}>
+									<ExternalLink />
+								</Button>
 							{/snippet}
 							<div>
 								<p>View Event Page</p>
 							</div>
-						</Popover.Mobile>
+						</TooltipSimple>
 					{/if}
 				</div>
 			</div>

--- a/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/+page.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/+page.svelte
@@ -174,7 +174,7 @@
 		<Button href="/guild/{data.guild.id}/events" variant="secondary">Back to Events</Button>
 	</div>
 
-	<MemberList members={(members ?? []).concat(bans ?? [])} {teams} {event} />
+	<MemberList members={(members ?? []).concat(bans ?? [])} {teams} {event} teamWords={data.teamWords} />
 
 	<div class="flex flex-col rounded-md border-2 bg-card p-4">
 		{#if event.type === +EventType.FarmingWeight && cropWeights}

--- a/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/columns.ts
+++ b/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/columns.ts
@@ -1,7 +1,6 @@
 import type { components } from '$lib/api/api';
 import { renderComponent, renderSnippet } from '$ui/data-table';
 import type { ColumnDef } from '@tanstack/table-core';
-// import Bed from 'lucide-svelte/icons/bed';
 import { createRawSnippet } from 'svelte';
 import MemberTableActions from './member-table-actions.svelte';
 import CircleOff from 'lucide-svelte/icons/circle-off';
@@ -9,6 +8,8 @@ import LogOut from 'lucide-svelte/icons/log-out';
 import Activity from 'lucide-svelte/icons/activity';
 import DataTableColumnHeader from './data-table-column-header.svelte';
 import { Pause } from 'lucide-svelte';
+import MemberTeamRow from './member-team-row.svelte';
+import MemberRow from './member-row.svelte';
 
 export type AdminEventMember = components['schemas']['AdminEventMemberDto'];
 export type AdminEventTeam = components['schemas']['EventTeamWithMembersDto'];
@@ -23,23 +24,6 @@ const statusCellSnippet = createRawSnippet<[string]>((getStatus) => {
 	};
 	return {
 		render: () => `<div class="font-medium">${map[+status as keyof typeof map] ?? 'Unknown'}</div>`,
-	};
-});
-
-const nameCellSnippet = createRawSnippet<[{ name: string; uuid: string }]>((getData) => {
-	const { name, uuid } = getData();
-	return {
-		render: () =>
-			`<div class="flex flex-row items-center gap-2">
-				<img
-					src="https://mc-heads.net/avatar/${uuid}"
-					class="aspect-square w-6 rounded-sm"
-					alt="Player Head"
-				/>
-				<a href="/@${uuid}" target="_blank" class="flex flex-row items-center gap-1 underline">
-					${name}
-				</a>
-			</div>`,
 	};
 });
 
@@ -60,10 +44,7 @@ export const getColumns = (
 			accessorKey: 'playerName',
 			header: 'Name',
 			cell: ({ row }) => {
-				return renderSnippet(nameCellSnippet, {
-					name: row.getValue('playerName') as string,
-					uuid: row.original.playerUuid as string,
-				});
+				return renderComponent(MemberRow, { member: row.original });
 			},
 		},
 		{
@@ -89,10 +70,12 @@ export const getColumns = (
 				}),
 			cell: ({ row }) => {
 				const teamId = row.getValue('teamId');
-				if (!teamId) return 'None';
-				const team = teams[teamId as number];
-				if (!team) return 'Unknown';
-				return team.name;
+				const team = teamId ? teams[teamId as number] : undefined;
+				return renderComponent(MemberTeamRow, {
+					member: row.original,
+					team,
+					actions,
+				});
 			},
 			filterFn: (row, id, value) => {
 				return value.includes(row.original.teamId?.toString());

--- a/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member-row.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member-row.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import type { components } from '$lib/api/api';
+	import * as Popover from '$ui/popover';
+	import FileText from 'lucide-svelte/icons/file-text';
+
+	interface Props {
+		member: components['schemas']['EventMemberDto'] | components['schemas']['AdminEventMemberDto'];
+	}
+
+	let { member }: Props = $props();
+</script>
+
+<div class="flex flex-row items-center gap-2">
+	<img src="https://mc-heads.net/avatar/{member.playerUuid}" class="aspect-square w-6 rounded-sm" alt="Player Head" />
+	<a
+		href="/@{member.playerUuid}/{member.profileId ?? ''}"
+		target="_blank"
+		class="flex flex-row items-center gap-1 underline"
+	>
+		{member.playerName}
+	</a>
+	{#if member.notes}
+		<Popover.Mobile>
+			{#snippet trigger()}
+				<FileText size={16} class="-mb-1 text-destructive" />
+			{/snippet}
+			<div class="text-sm">
+				<p>{member.notes || 'Member Left'}</p>
+			</div>
+		</Popover.Mobile>
+	{/if}
+</div>

--- a/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member-table-actions.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member-table-actions.svelte
@@ -6,6 +6,8 @@
 	import Trash_2 from 'lucide-svelte/icons/trash-2';
 	import { goto } from '$app/navigation';
 	import Undo_2 from 'lucide-svelte/icons/undo-2';
+	import CopyToClipboard from '$comp/copy-to-clipboard.svelte';
+	import { cn } from '$lib/utils';
 
 	let { member, actions }: { member: AdminEventMember; actions: Record<string, (member: AdminEventMember) => void> } =
 		$props();
@@ -40,6 +42,36 @@
 			<DropdownMenu.Item onclick={() => goto(`/@${member.playerUuid}/${member.profileId}`)}
 				>View stats</DropdownMenu.Item
 			>
+			<DropdownMenu.Item>
+				{#snippet child({ props })}
+					<CopyToClipboard
+						size="sm"
+						class={cn(props.class ?? '', 'w-full cursor-pointer justify-start px-2 py-0')}
+						text={member.playerUuid ?? ''}
+						iconClass="p-0 m-0">Copy Player Uuid</CopyToClipboard
+					>
+				{/snippet}
+			</DropdownMenu.Item>
+			<DropdownMenu.Item>
+				{#snippet child({ props })}
+					<CopyToClipboard
+						size="sm"
+						class={cn(props.class ?? '', 'w-full cursor-pointer justify-start px-2 py-0')}
+						text={member.profileId ?? ''}
+						iconClass="p-0 m-0">Copy Profile Uuid</CopyToClipboard
+					>
+				{/snippet}
+			</DropdownMenu.Item>
+			<DropdownMenu.Item>
+				{#snippet child({ props })}
+					<CopyToClipboard
+						size="sm"
+						class={cn(props.class ?? '', 'w-full cursor-pointer justify-start px-2 py-0')}
+						text={member.accountId?.toString() ?? ''}
+						iconClass="p-0 m-0">Copy Discord Id</CopyToClipboard
+					>
+				{/snippet}
+			</DropdownMenu.Item>
 		</DropdownMenu.Content>
 	</DropdownMenu.Root>
 </div>

--- a/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member-team-row.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member-team-row.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import Ellipsis from 'lucide-svelte/icons/ellipsis';
+	import Plus from 'lucide-svelte/icons/plus';
+	import * as DropdownMenu from '$ui/dropdown-menu';
+	import { Button } from '$ui/button';
+	import type { AdminEventMember, AdminEventTeam } from './columns';
+	import Crown from 'lucide-svelte/icons/crown';
+	import CopyToClipboard from '$comp/copy-to-clipboard.svelte';
+	import { cn } from '$lib/utils';
+	import Trash_2 from 'lucide-svelte/icons/trash-2';
+
+	interface Props {
+		member: AdminEventMember;
+		team?: AdminEventTeam;
+		actions: Record<string, (member: AdminEventMember) => void>;
+	}
+
+	let { member, team, actions }: Props = $props();
+	let isOwner = $derived(member.accountId === team?.ownerId);
+</script>
+
+<div class="flex flex-row items-center gap-2">
+	{#if !team}
+		<span class="text-muted-foreground">None!</span>
+		<Button variant="ghost" size="icon" onclick={() => actions['addtoteam'](member)} class="relative size-8 p-0">
+			<span class="sr-only">Add to team</span>
+			<Plus />
+		</Button>
+	{:else}
+		<span>{team.name}</span>
+		{#if isOwner}
+			<Crown size={16} class="w-4 text-completed" />
+		{/if}
+		<DropdownMenu.Root>
+			<DropdownMenu.Trigger>
+				{#snippet child({ props })}
+					<Button {...props} variant="ghost" size="icon" class="relative size-8 p-0">
+						<span class="sr-only">Open menu</span>
+						<Ellipsis />
+					</Button>
+				{/snippet}
+			</DropdownMenu.Trigger>
+			<DropdownMenu.Content>
+				<DropdownMenu.Group>
+					<DropdownMenu.GroupHeading>Join Code</DropdownMenu.GroupHeading>
+					<DropdownMenu.Item>
+						{#snippet child({ props })}
+							<CopyToClipboard
+								size="sm"
+								class={cn(props.class ?? '', 'w-full cursor-pointer justify-start px-2 py-0 font-mono')}
+								text={team.joinCode ?? ''}
+								iconClass="p-0 m-0">{team.joinCode}</CopyToClipboard
+							>
+						{/snippet}
+					</DropdownMenu.Item>
+				</DropdownMenu.Group>
+				<DropdownMenu.Separator />
+				<DropdownMenu.Group>
+					<DropdownMenu.GroupHeading>Manage</DropdownMenu.GroupHeading>
+					<!-- <DropdownMenu.Item
+						onclick={() => actions['editteam'](member)}
+						class="cursor-pointer"
+					>
+						<Settings size={16} />
+						Edit Team
+					</DropdownMenu.Item> -->
+					<DropdownMenu.Item
+						onclick={() => actions['promote'](member)}
+						class="cursor-pointer"
+						disabled={isOwner}
+					>
+						<Crown size={16} class="text-completed" />
+						Set as Owner
+					</DropdownMenu.Item>
+					{#if !isOwner}
+						<DropdownMenu.Item
+							onclick={() => actions['teamkick'](member)}
+							class="cursor-pointer"
+							disabled={isOwner}
+						>
+							<Trash_2 size={16} class="text-destructive" />
+							Kick from team
+						</DropdownMenu.Item>
+					{/if}
+					{#if team.members.length <= 1}
+						<DropdownMenu.Item onclick={() => actions['deleteteam'](member)} class="cursor-pointer">
+							<Trash_2 size={16} class="text-destructive" />
+							Delete Team
+						</DropdownMenu.Item>
+					{/if}
+				</DropdownMenu.Group>
+			</DropdownMenu.Content>
+		</DropdownMenu.Root>
+	{/if}
+</div>

--- a/src/routes/(auth)/guild/[id=snowflake]/events/+page.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/events/+page.svelte
@@ -97,12 +97,10 @@
 					</div>
 					<div class="flex flex-col gap-2 p-4">
 						<Popover.Mobile>
-							{#snippet trigger()}
-								<div>
-									<Button href="/guild/{event.guildId}/event/{event.id}">
-										<Settings />
-									</Button>
-								</div>
+							{#snippet child({ props })}
+								<Button href="/guild/{event.guildId}/event/{event.id}" {...props}>
+									<Settings />
+								</Button>
 							{/snippet}
 							<div>
 								<p>Edit Event</p>
@@ -111,12 +109,10 @@
 
 						{#if event.approved}
 							<Popover.Mobile>
-								{#snippet trigger()}
-									<div>
-										<Button href="/event/{event.id}" target="_blank">
-											<ExternalLink />
-										</Button>
-									</div>
+								{#snippet child({ props })}
+									<Button href="/event/{event.id}" target="_blank" {...props}>
+										<ExternalLink />
+									</Button>
 								{/snippet}
 								<div>
 									<p>View Event Page</p>

--- a/src/routes/(auth)/guild/[id=snowflake]/jacob/jacobsettings.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/jacob/jacobsettings.svelte
@@ -73,9 +73,9 @@
 			<form method="post" action="{page.url.pathname}?/send" use:enhance>
 				<input type="hidden" name="id" value={lb.id} />
 				<Popover.Mobile>
-					{#snippet trigger()}
+					{#snippet child({ props })}
 						<div>
-							<Button type="submit" color="green">
+							<Button type="submit" color="green" {...props}>
 								<Mail />
 							</Button>
 						</div>
@@ -88,9 +88,9 @@
 			<form method="post" action="{page.url.pathname}?/clear" use:enhance>
 				<input type="hidden" name="id" value={lb.id} />
 				<Popover.Mobile>
-					{#snippet trigger()}
+					{#snippet child({ props })}
 						<div>
-							<Button type="submit" color="yellow">
+							<Button type="submit" color="yellow" {...props}>
 								<RefreshCcw />
 							</Button>
 						</div>
@@ -99,8 +99,8 @@
 				</Popover.Mobile>
 			</form>
 			<Popover.Mobile>
-				{#snippet trigger()}
-					<Button onclick={() => (confirmModal = true)} variant="destructive">
+				{#snippet child({ props })}
+					<Button onclick={() => (confirmModal = true)} variant="destructive" {...props}>
 						<Trash2 />
 					</Button>
 				{/snippet}

--- a/src/routes/@[id=id]/[[profile]]/charts/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/charts/+page.svelte
@@ -142,8 +142,8 @@
 						<p class="text-sm leading-none">Show Pests</p>
 						{#if !pestIncreased}
 							<Tooltip.Simple side="bottom">
-								{#snippet trigger()}
-									<Switch bind:checked={pestToggle} disabled={true} />
+								{#snippet child({ props })}
+									<Switch bind:checked={pestToggle} disabled={true} {...props} />
 								{/snippet}
 								<div class="p-2">
 									<p class="text-sm">Pest data not available for this time period.</p>

--- a/src/routes/event/[event=slug]/membership/+page.server.ts
+++ b/src/routes/event/[event=slug]/membership/+page.server.ts
@@ -5,7 +5,6 @@ import {
 	GetAccount,
 	GetEventDetails,
 	GetEventTeam,
-	GetEventTeamWords,
 	GetEventTeams,
 	JoinEvent,
 	JoinEventTeam,
@@ -41,7 +40,6 @@ export const load = (async ({ locals, parent, params }) => {
 
 	if (event.maxTeamMembers !== 0 || event.maxTeams !== 0) {
 		const { data: teams } = await GetEventTeams(eventId).catch(() => ({ data: undefined }));
-		const { data: words } = await GetEventTeamWords().catch(() => ({ data: undefined }));
 
 		if (member?.teamId && token) {
 			const { data: team } = await GetEventTeam(token, eventId, member.teamId).catch(() => ({ data: undefined }));
@@ -51,7 +49,7 @@ export const load = (async ({ locals, parent, params }) => {
 				member,
 				teams,
 				event,
-				words,
+				words: locals.cache?.teamwords,
 				team,
 			};
 		}
@@ -61,7 +59,7 @@ export const load = (async ({ locals, parent, params }) => {
 			member,
 			teams,
 			event,
-			words,
+			words: locals.cache?.teamwords,
 		};
 	}
 
@@ -159,7 +157,7 @@ export const actions: Actions = {
 		}
 
 		const data = await request.formData();
-		const teamName = (data.get('name') as string) || undefined;
+		const teamName = data.get('name') as string;
 
 		if (!teamName) {
 			return fail(400, { error: 'Invalid request' });

--- a/src/routes/event/[event=slug]/membership/+page.svelte
+++ b/src/routes/event/[event=slug]/membership/+page.svelte
@@ -12,17 +12,15 @@
 	import { Input } from '$ui/input';
 	import { SelectSimple } from '$ui/select';
 	import Check from 'lucide-svelte/icons/check';
-	import RefreshCcw from 'lucide-svelte/icons/refresh-ccw';
 	import Trash from 'lucide-svelte/icons/trash-2';
 	import Crown from 'lucide-svelte/icons/crown';
 	import CopyToClipboard from '$comp/copy-to-clipboard.svelte';
-	import ComboBox from '$comp/ui/combobox/combo-box.svelte';
 	import { getBreadcrumb, type Crumb } from '$lib/hooks/breadcrumb.svelte';
-	import { watch } from 'runed';
 	import { invalidate } from '$app/navigation';
 	import { getFavoritesContext } from '$lib/stores/favorites.svelte';
 	import VisibleToggle from '$comp/visible-toggle.svelte';
 	import type { components } from '$lib/api/api';
+	import TeamNameSelector from '$comp/events/team-name-selector.svelte';
 
 	interface Props {
 		data: PageData;
@@ -40,47 +38,7 @@
 
 	let kickMemberModal = $state(false);
 	let promoteMemberModal = $state(false);
-	let leaveTeamModal = $state(false);
 	let selectedMember = $state<components['schemas']['EventMemberDetailsDto']>();
-
-	let picked1 = $state('');
-	let picked2 = $state('');
-	let picked3 = $state('');
-
-	function generateTeamName() {
-		const firstWords = data.words?.first ?? [];
-		const secondWords = data.words?.second ?? [];
-		const thirdWords = data.words?.third ?? [];
-
-		const first = firstWords[Math.floor(Math.random() * firstWords.length)].replaceAll(' ', '_');
-		const second = secondWords[Math.floor(Math.random() * secondWords.length)].replaceAll(' ', '_');
-		const third = thirdWords[Math.floor(Math.random() * thirdWords.length)].replaceAll(' ', '_');
-
-		if (Math.random() > 0.5) {
-			picked1 = first;
-			picked3 = '';
-
-			if (Math.random() > 0.5) {
-				picked2 = second;
-			} else {
-				picked2 = third;
-			}
-		} else {
-			picked1 = first;
-			picked2 = second;
-			picked3 = third;
-		}
-
-		updateName();
-
-		if (name.length > 32) {
-			generateTeamName();
-		}
-	}
-
-	function updateName() {
-		name = (picked1 ?? '') + ' ' + (picked2 ?? '') + ' ' + (picked3 ?? '').trim();
-	}
 
 	let event = $derived(data.event);
 	let teams = $derived(
@@ -112,24 +70,7 @@
 	let joinable = $derived(joinEnds > Date.now() && !data.member?.disqualified);
 	let loading = $state(false);
 
-	let name = $state('');
 	let codeVisible = $state(false);
-
-	watch(
-		() => data.words,
-		(words) => {
-			if (event.mode !== 'solo' && words) {
-				generateTeamName();
-			}
-		}
-	);
-
-	let words = $derived(
-		Array.from(
-			new Set([...(data.words?.first ?? []), ...(data.words?.second ?? []), ...(data.words?.third ?? [])]),
-			(w) => ({ value: w.replaceAll(' ', '_'), label: w })
-		)
-	);
 
 	const crumbs = $derived<Crumb[]>([
 		{
@@ -480,45 +421,7 @@
 							<h3 class="text-xl font-semibold">Update Your Team</h3>
 							<p>Change the name of your team!</p>
 							<div class="flex flex-row items-center gap-2 text-primary">
-								<input type="hidden" name="name" value={name} hidden />
-								<div class="flex flex-col gap-2">
-									<p class="text-xl font-semibold">{name.replaceAll('_', ' ')}</p>
-									<div class="flex max-w-sm flex-row flex-wrap gap-1 lg:flex-nowrap">
-										<Button
-											variant="secondary"
-											onclick={generateTeamName}
-											disabled={loading}
-											class="order-5 lg:order-1"
-										>
-											<RefreshCcw />
-										</Button>
-										<ComboBox
-											options={words}
-											bind:value={picked1}
-											exclude={[picked2, picked3]}
-											onChange={updateName}
-											placeholder="Select Word"
-											btnClass="order-2"
-										/>
-										<ComboBox
-											options={words}
-											bind:value={picked2}
-											exclude={[picked1, picked3]}
-											onChange={updateName}
-											placeholder="Select Word"
-											btnClass="order-3"
-										/>
-										<ComboBox
-											options={words}
-											bind:value={picked3}
-											exclude={[picked1, picked2]}
-											onChange={updateName}
-											placeholder="Select Word"
-											clear={true}
-											btnClass="order-4"
-										/>
-									</div>
-								</div>
+								<TeamNameSelector words={data.words} bind:loading />
 							</div>
 							<div class="flex flex-row gap-2">
 								<Button type="submit" disabled={loading}>Update Team Name</Button>
@@ -561,48 +464,8 @@
 							list.
 						</p>
 						<div class="flex flex-row items-center gap-2 text-primary">
-							<input type="hidden" name="name" value={name} hidden />
-
 							<div class="flex flex-col gap-2">
-								<p class="text-xl font-semibold">{name.replaceAll('_', ' ')}</p>
-								<div class="flex max-w-sm flex-row flex-wrap gap-1 lg:flex-nowrap">
-									<Button
-										variant="secondary"
-										disabled={!joined}
-										onclick={generateTeamName}
-										class="order-5 lg:order-1"
-									>
-										<RefreshCcw />
-									</Button>
-									<ComboBox
-										options={words}
-										bind:value={picked1}
-										exclude={[picked2, picked3]}
-										onChange={updateName}
-										placeholder="Select Word"
-										disabled={!joined}
-										btnClass="order-2"
-									/>
-									<ComboBox
-										options={words}
-										bind:value={picked2}
-										exclude={[picked1, picked3]}
-										onChange={updateName}
-										placeholder="Select Word"
-										disabled={!joined}
-										btnClass="order-3"
-									/>
-									<ComboBox
-										options={words}
-										bind:value={picked3}
-										exclude={[picked1, picked2]}
-										onChange={updateName}
-										placeholder="Select Word"
-										disabled={!joined}
-										clear={true}
-										btnClass="order-4"
-									/>
-								</div>
+								<TeamNameSelector words={data.words} bind:loading />
 							</div>
 						</div>
 						<Button type="submit" disabled={!data.member || !joined || loading}>Create Team</Button>


### PR DESCRIPTION
- Correct some instances of nested buttons
- Event moderators can now do the following
  - Create a team for a user
  - See join codes for teams
  - Kick member from team
  - Add a member to a team
  - Delete a team

Editing a team is missing for now.