### PR TITLE
Sort tools by approximate weight

### DIFF
--- a/src/components/items/tools/farmingtools.svelte
+++ b/src/components/items/tools/farmingtools.svelte
@@ -27,14 +27,9 @@
 			};
 
 			actualTools = FT.fromArray(tools as EliteItemDto[], options).sort((a, b) => {
-				const aCounter =
-					a.counter !== undefined && a.counter !== null ? a.counter : Math.abs(a.cultivating ?? 0);
-				const bCounter =
-					b.counter !== undefined && b.counter !== null ? b.counter : Math.abs(b.cultivating ?? 0);
-
 				return (
-					calcWeightForCrop(b.crop ?? Crop.Wheat, bCounter) -
-					calcWeightForCrop(a.crop ?? Crop.Wheat, aCounter)
+					calcWeightForCrop(b.crop ?? Crop.Wheat, b.farmed) -
+					calcWeightForCrop(a.crop ?? Crop.Wheat, a.farmed)
 				);
 			});
 		}

--- a/src/components/items/tools/farmingtools.svelte
+++ b/src/components/items/tools/farmingtools.svelte
@@ -27,9 +27,14 @@
 			};
 
 			actualTools = FT.fromArray(tools as EliteItemDto[], options).sort((a, b) => {
+				const aCounter =
+					a.counter !== undefined && a.counter !== null ? a.counter : Math.abs(a.cultivating ?? 0);
+				const bCounter =
+					b.counter !== undefined && b.counter !== null ? b.counter : Math.abs(b.cultivating ?? 0);
+
 				return (
-					calcWeightForCrop(b.crop ?? Crop.Wheat, Math.abs(b.cultivating) ?? 0) -
-					calcWeightForCrop(a.crop ?? Crop.Wheat, Math.abs(a.cultivating) ?? 0)
+					calcWeightForCrop(b.crop ?? Crop.Wheat, bCounter) -
+					calcWeightForCrop(a.crop ?? Crop.Wheat, aCounter)
 				);
 			});
 		}

--- a/src/components/items/tools/farmingtools.svelte
+++ b/src/components/items/tools/farmingtools.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 	import { Button } from '$ui/button';
 	import Farmingtool from '$comp/items/tools/farmingtool.svelte';
-	import { FarmingTool as FT, getCropMilestoneLevels, type EliteItemDto } from 'farming-weight';
+	import {
+		calcWeightForCrop,
+		Crop,
+		FarmingTool as FT,
+		getCropMilestoneLevels,
+		type EliteItemDto,
+	} from 'farming-weight';
 	import { getStatsContext } from '$lib/stores/stats.svelte';
 	import { watch } from 'runed';
 
@@ -20,7 +26,12 @@
 				milestones: getCropMilestoneLevels(garden?.crops ?? {}),
 			};
 
-			actualTools = FT.fromArray(tools as EliteItemDto[], options);
+			actualTools = FT.fromArray(tools as EliteItemDto[], options).sort((a, b) => {
+				return (
+					calcWeightForCrop(b.crop ?? Crop.Wheat, Math.abs(b.cultivating) ?? 0) -
+					calcWeightForCrop(a.crop ?? Crop.Wheat, Math.abs(a.cultivating) ?? 0)
+				);
+			});
 		}
 	);
 </script>


### PR DESCRIPTION
sorts tools by their approxomite weight, the only time it would really not work is if someone has an overflowed counter and it was close to 0, but usually it should be fine

| Before | After |
|--------|--------|
| ![chrome_joTWhHSmr0](https://github.com/user-attachments/assets/5574542a-295e-426c-b50d-ac8f78cf1d7b) | ![zEPJxOEISJ](https://github.com/user-attachments/assets/6c34eed6-68fc-4080-92d5-ecb7fc266788) | 