### PR TITLE
fix header warning on chrome

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -35,17 +35,13 @@ async function ResolveWithSecurityHeaders(
 ): Promise<ReturnType<Handle>> {
 	const response = await resolve(event);
 
-	let permissionsPolicy =
-		'accelerometer=(), autoplay=(), camera=(), encrypted-media=(), fullscreen=(), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), sync-xhr=(), usb=(), xr-spatial-tracking=(), geolocation=()';
-
-	if (!event.request.headers.get('user-agent')?.includes('Chrome')) {
-		permissionsPolicy = permissionsPolicy.replace('camera=(), ', 'camera=(), document-domain=(),');
-	}
-
 	// Security headers
 	response.headers.set('X-Frame-Options', 'SAMEORIGIN');
 	response.headers.set('Referrer-Policy', 'no-referrer');
-	response.headers.set('Permissions-Policy', permissionsPolicy);
+	response.headers.set(
+		'Permissions-Policy',
+		'accelerometer=(), autoplay=(), camera=(), encrypted-media=(), fullscreen=(), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), sync-xhr=(), usb=(), xr-spatial-tracking=(), geolocation=()'
+	);
 	response.headers.set('X-Content-Type-Options', 'nosniff');
 
 	return response;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -35,13 +35,17 @@ async function ResolveWithSecurityHeaders(
 ): Promise<ReturnType<Handle>> {
 	const response = await resolve(event);
 
+	let permissionsPolicy =
+		'accelerometer=(), autoplay=(), camera=(), encrypted-media=(), fullscreen=(), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), sync-xhr=(), usb=(), xr-spatial-tracking=(), geolocation=()';
+
+	if (!event.request.headers.get('user-agent')?.includes('Chrome')) {
+		permissionsPolicy = permissionsPolicy + 'document-domain=(),';
+	}
+
 	// Security headers
 	response.headers.set('X-Frame-Options', 'SAMEORIGIN');
 	response.headers.set('Referrer-Policy', 'no-referrer');
-	response.headers.set(
-		'Permissions-Policy',
-		'accelerometer=(), autoplay=(), camera=(), document-domain=(), encrypted-media=(), fullscreen=(), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), sync-xhr=(), usb=(), xr-spatial-tracking=(), geolocation=()'
-	);
+	response.headers.set('Permissions-Policy', permissionsPolicy);
 	response.headers.set('X-Content-Type-Options', 'nosniff');
 
 	return response;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -39,7 +39,7 @@ async function ResolveWithSecurityHeaders(
 		'accelerometer=(), autoplay=(), camera=(), encrypted-media=(), fullscreen=(), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), sync-xhr=(), usb=(), xr-spatial-tracking=(), geolocation=()';
 
 	if (!event.request.headers.get('user-agent')?.includes('Chrome')) {
-		permissionsPolicy = permissionsPolicy + 'document-domain=(),';
+		permissionsPolicy = permissionsPolicy.replace('camera=(), ', 'camera=(), document-domain=(),');
 	}
 
 	// Security headers


### PR DESCRIPTION
https://developer.chrome.com/blog/immutable-document-domain

it worked with just `+` instead of the `.replace()` to keep it in alphabetical order but idk if like it still should be that way or something so im jsut gonna play it safe

also idk if theres a better way to check for chrome i saw someone say do `window.chrome` but that doesnt work