### PR TITLE
Fix bazaar `otherCoins` number in rates

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"eslint": "^9.25.1",
 		"eslint-config-prettier": "^10.1.2",
 		"eslint-plugin-svelte": "^3.5.1",
-		"farming-weight": "^0.8.6",
+		"farming-weight": "^0.8.8",
 		"globals": "^15.15.0",
 		"layercake": "^8.4.2",
 		"layerchart": "^0.99.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^3.5.1
         version: 3.5.1(eslint@9.25.1(jiti@1.21.7))(svelte@5.28.2)
       farming-weight:
-        specifier: ^0.8.6
-        version: 0.8.6
+        specifier: ^0.8.8
+        version: 0.8.8
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -1275,8 +1275,8 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  farming-weight@0.8.6:
-    resolution: {integrity: sha512-cvQr2VkWtnX4o1NggsHDBKmow+uQPBwHP9V1Lz8TQYS8Sd+lo6eM/2exj3wFfDgBWz93AUmbFhuZAZ50BS/vxw==}
+  farming-weight@0.8.8:
+    resolution: {integrity: sha512-VXqKZl2UzoON14rwCe/sx47IUPfYEWkuicxbYlBhFL/8JFxpACSfK29/ngsJP6I8LKu1HzEVRKYHw8fHCYCy1g==}
 
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
@@ -3412,7 +3412,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  farming-weight@0.8.6: {}
+  farming-weight@0.8.8: {}
 
   fast-check@3.23.2:
     dependencies:

--- a/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
@@ -436,7 +436,8 @@
 						<BazaarRates
 							crop={selectedCropKey}
 							amount={info.collection}
-							otherCoins={info.npcCoins - info.coinSources['Collection']}
+							otherCoins={info.npcCoins -
+								(info.items[selectedCropKey] ?? info.collection) * info.npcPrice}
 						/>
 					</div>
 

--- a/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/rates/+page.svelte
@@ -435,7 +435,7 @@
 					<div class="-mx-2">
 						<BazaarRates
 							crop={selectedCropKey}
-							amount={info.collection}
+							amount={info.items[selectedCropKey] ?? info.collection}
 							otherCoins={info.npcCoins -
 								(info.items[selectedCropKey] ?? info.collection) * info.npcPrice}
 						/>


### PR DESCRIPTION
Fix bazaar `otherCoins` price in rates, which fixes pumpkin/melon rng drops being double counted.