### PR TITLE
Remove list dot explicitly

### DIFF
--- a/src/components/ui/sidebar/sidebar-menu-item.svelte
+++ b/src/components/ui/sidebar/sidebar-menu-item.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-menu-item"
 	data-sidebar="menu-item"
-	class={cn('group/menu-item relative', className)}
+	class={cn('group/menu-item relative list-none', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/src/components/ui/sidebar/sidebar-menu-sub-item.svelte
+++ b/src/components/ui/sidebar/sidebar-menu-sub-item.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-menu-sub-item"
 	data-sidebar="menu-sub-item"
-	class={cn('group/menu-sub-item relative', className)}
+	class={cn('group/menu-sub-item relative list-none', className)}
 	{...restProps}
 >
 	{@render children?.()}


### PR DESCRIPTION
For some reason it only shows up on Chromium browsers, so removed that (again) here after the components were updated.