### PR TITLE
Use elite face api instead of mc-heads in a lot of places

### DIFF
--- a/src/components/events/event-member.svelte
+++ b/src/components/events/event-member.svelte
@@ -7,6 +7,7 @@
 	import * as Tooltip from '$ui/tooltip';
 	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 	import { formatIgn } from '$lib/format';
+	import PlayerHead from '$comp/sidebar/player-head.svelte';
 
 	interface Props {
 		owner?: boolean;
@@ -70,11 +71,7 @@
 						</p>
 					</div>
 				{/if}
-				<img
-					src="https://mc-heads.net/avatar/{member.playerUuid}"
-					alt="Player Head"
-					class="pixelated aspect-square size-8 rounded-sm"
-				/>
+				<PlayerHead uuid={member.playerUuid} size="lg" />
 				<p class="text-lg">{formatIgn(member.playerName, member.meta)}</p>
 				{#if owner}
 					<Tooltip.Simple>

--- a/src/components/sidebar/player-head.svelte
+++ b/src/components/sidebar/player-head.svelte
@@ -4,8 +4,8 @@
 
 <script lang="ts">
 	interface Props {
-		uuid?: string;
-		size?: 'sm' | 'md' | 'lg';
+		uuid?: string | null;
+		size?: keyof typeof sizes;
 	}
 
 	let { uuid, size = 'sm' }: Props = $props();
@@ -18,7 +18,7 @@
 		errored = true;
 	}
 
-	function onload() {
+	async function onload() {
 		loading = false;
 	}
 
@@ -26,21 +26,25 @@
 		sm: 'size-4 rounded-[0.12rem]',
 		md: 'size-6 rounded-sm',
 		lg: 'size-8 rounded-sm',
+		xl: 'size-10 rounded-sm',
+		'2xl': 'size-12 rounded-sm',
 	};
 </script>
 
 {#if !errored && uuid}
-	{#if loading}
-		<User class="aspect-square {sizes[size]}" />
-	{/if}
-	<img
-		loading="lazy"
-		src="https://mc-heads.net/avatar/{uuid}"
-		alt={loading ? '' : 'Player Head'}
-		{onload}
-		{onerror}
-		class="aspect-square {sizes[size]} pixelated"
-	/>
+	<div class="relative {sizes[size]}">
+		{#if loading}
+			<User class="aspect-square {sizes[size]} absolute top-0 left-0" />
+		{/if}
+		<img
+			loading="lazy"
+			src="https://api.elitebot.dev/account/{uuid}/face.png"
+			alt={loading ? '' : 'Player Head'}
+			{onload}
+			{onerror}
+			class="aspect-square {sizes[size]} pixelated absolute top-0 left-0"
+		/>
+	</div>
 {:else}
 	<User class="aspect-square {sizes[size]}" />
 {/if}

--- a/src/lib/api/api.d.ts
+++ b/src/lib/api/api.d.ts
@@ -2746,6 +2746,7 @@ export interface components {
         MinecraftAccountDto: {
             id: string;
             name: string;
+            formattedName: string;
             primaryAccount: boolean;
             discordId?: string | null;
             discordUsername?: string | null;
@@ -2891,20 +2892,14 @@ export interface components {
             youtube?: string | null;
         };
         PlayerRequest: Record<string, never>;
-        /** @description the dto used to send an error response to the client */
         ErrorResponse: {
             /**
              * Format: int32
-             * @description the http status code sent to the client. default is 400.
              * @default 400
              */
             statusCode: number;
-            /**
-             * @description the message for the error response
-             * @default One or more errors occurred!
-             */
+            /** @default One or more errors occurred! */
             message: string;
-            /** @description the collection of errors for the current context */
             errors: {
                 [key: string]: string[];
             };
@@ -4799,9 +4794,7 @@ export interface components {
             /** Format: int32 */
             level: number;
         };
-        /** @description Provides a mechanism for examining the structural content of a JSON value without automatically instantiating data values. */
         JsonDocument: {
-            /** @description Gets the root element of this JSON document. */
             rootElement: unknown;
         };
         GetSpecifiedSkyblockItemsResponse: {

--- a/src/lib/api/swagger.json
+++ b/src/lib/api/swagger.json
@@ -9272,6 +9272,7 @@
         "required": [
           "id",
           "name",
+          "formattedName",
           "primaryAccount",
           "settings",
           "properties",
@@ -9283,6 +9284,9 @@
             "type": "string"
           },
           "name": {
+            "type": "string"
+          },
+          "formattedName": {
             "type": "string"
           },
           "primaryAccount": {
@@ -9782,7 +9786,6 @@
       },
       "ErrorResponse": {
         "type": "object",
-        "description": "the dto used to send an error response to the client",
         "additionalProperties": false,
         "required": [
           "statusCode",
@@ -9792,18 +9795,15 @@
         "properties": {
           "statusCode": {
             "type": "integer",
-            "description": "the http status code sent to the client. default is 400.",
             "format": "int32",
             "default": 400
           },
           "message": {
             "type": "string",
-            "description": "the message for the error response",
             "default": "One or more errors occurred!"
           },
           "errors": {
             "type": "object",
-            "description": "the collection of errors for the current context",
             "additionalProperties": {
               "type": "array",
               "items": {
@@ -15894,15 +15894,12 @@
       },
       "JsonDocument": {
         "type": "object",
-        "description": "Provides a mechanism for examining the structural content of a JSON value without automatically instantiating data values.",
         "additionalProperties": false,
         "required": [
           "rootElement"
         ],
         "properties": {
-          "rootElement": {
-            "description": "Gets the root element of this JSON document."
-          }
+          "rootElement": {}
         }
       },
       "GetSpecifiedSkyblockItemsResponse": {

--- a/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member-row.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member-row.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import PlayerHead from '$comp/sidebar/player-head.svelte';
 	import type { components } from '$lib/api/api';
 	import * as Popover from '$ui/popover';
 	import FileText from '@lucide/svelte/icons/file-text';
@@ -11,7 +12,7 @@
 </script>
 
 <div class="flex flex-row items-center gap-2">
-	<img src="https://mc-heads.net/avatar/{member.playerUuid}" class="aspect-square w-6 rounded-sm" alt="Player Head" />
+	<PlayerHead uuid={member.playerUuid} size="lg" />
 	<a
 		href="/@{member.playerUuid}/{member.profileId ?? ''}"
 		target="_blank"

--- a/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/event/[eventId=snowflake]/member.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import PlayerHead from '$comp/sidebar/player-head.svelte';
 	import type { components } from '$lib/api/api';
 	import { formatIgn } from '$lib/format';
 	import * as Popover from '$ui/popover';
@@ -15,11 +16,7 @@
 <div class="flex w-full flex-row justify-between gap-1">
 	<div class="flex flex-row items-center gap-2">
 		{@render children?.()}
-		<img
-			src="https://mc-heads.net/avatar/{member.playerUuid}"
-			class="aspect-square w-8 rounded-sm"
-			alt="Player Head"
-		/>
+		<PlayerHead uuid={member.playerUuid} size="lg" />
 		<a
 			href="/@{member.playerUuid}/{member.profileId ?? ''}"
 			target="_blank"

--- a/src/routes/(auth)/guild/[id=snowflake]/jacob/+page.svelte
+++ b/src/routes/(auth)/guild/[id=snowflake]/jacob/+page.svelte
@@ -18,6 +18,7 @@
 	import { page } from '$app/state';
 	import { getFavoritesContext } from '$lib/stores/favorites.svelte';
 	import { getBreadcrumb, type Crumb } from '$lib/hooks/breadcrumb.svelte';
+	import PlayerHead from '$comp/sidebar/player-head.svelte';
 
 	interface Props {
 		data: PageData;
@@ -136,11 +137,7 @@
 												<Trash2 size={16} />
 											</Button>
 										</form>
-										<img
-											class="pixelated h-8 w-8"
-											src="https://mc-heads.net/avatar/{p.uuid}/8"
-											alt="User Avatar"
-										/>
+										<PlayerHead uuid={p.uuid} size="lg" />
 										<p>{p.crop}</p>
 										<p>{getReadableSkyblockDate(p.timestamp)}</p>
 										<Button size="sm" href="/contest/{p.timestamp}" color="alternative">View</Button

--- a/src/routes/@[id=id]/[[profile]]/+page.svelte
+++ b/src/routes/@[id=id]/[[profile]]/+page.svelte
@@ -65,7 +65,7 @@
 <Head
 	title="{ctx.ignMeta} ({profile?.profileName}) | Farming Weight"
 	{description}
-	imageUrl="https://mc-heads.net/head/{uuid}/left.png"
+	imageUrl="https://api.elitebot.dev/account/{uuid}/face.png"
 >
 	<link rel="preload" href="/images/cropatlas.webp" as="image" />
 </Head>

--- a/src/routes/@[id=id]/[[profile]]/nav-crumbs.svelte
+++ b/src/routes/@[id=id]/[[profile]]/nav-crumbs.svelte
@@ -166,7 +166,7 @@
 		breadcrumb.setOverride(crumbs);
 		sidebarnav.setNav('Stats', sidebarCrumbs);
 		favorites.setPage({
-			icon: account?.id ? `https://mc-heads.net/avatar/${account.id}` : undefined,
+			icon: account?.id ? `https://api.elitebot.dev/account/${account.id}/face.png` : undefined,
 			name: document.title,
 			href: page.url.pathname,
 		});

--- a/src/routes/event/[event=slug]/membership/+page.svelte
+++ b/src/routes/event/[event=slug]/membership/+page.svelte
@@ -21,6 +21,7 @@
 	import VisibleToggle from '$comp/visible-toggle.svelte';
 	import type { components } from '$lib/api/api';
 	import TeamNameSelector from '$comp/events/team-name-selector.svelte';
+	import PlayerHead from '$comp/sidebar/player-head.svelte';
 
 	interface Props {
 		data: PageData;
@@ -330,11 +331,7 @@
 						{#each ownTeam.members ?? [] as member (member.playerUuid)}
 							<div class="flex flex-row justify-between">
 								<div class="flex flex-row items-center gap-2">
-									<img
-										src="https://mc-heads.net/avatar/{member.playerUuid}"
-										alt="Player Head"
-										class="pixelated aspect-square h-8 w-8 rounded-sm"
-									/>
+									<PlayerHead uuid={member.playerUuid} size="lg" />
 									<p>{member.playerName}</p>
 									{#if ownTeam.ownerUuid === member.playerUuid}
 										<Popover.Mobile>

--- a/src/routes/profile/minecraftAccount.svelte
+++ b/src/routes/profile/minecraftAccount.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import CopyToClipboard from '$comp/copy-to-clipboard.svelte';
+	import PlayerHead from '$comp/sidebar/player-head.svelte';
 	import type { components } from '$lib/api/api';
 	import { Button } from '$ui/button';
 	import * as Popover from '$ui/popover';
@@ -17,7 +18,7 @@
 <div class="bg-card flex flex-col rounded-md p-4">
 	<div class="flex flex-row items-center justify-between gap-2">
 		<div class="flex flex-row items-center gap-4">
-			<img class="pixel w-12" src="https://mc-heads.net/head/{mc.id}" alt="{mc.name} player skull" />
+			<PlayerHead uuid={mc.id} size="2xl" />
 			<h1 class="font-mono text-xl font-semibold">{mc.name}</h1>
 
 			{#if mc.primaryAccount}

--- a/src/routes/server/[guild=slug]/jacobentry.svelte
+++ b/src/routes/server/[guild=slug]/jacobentry.svelte
@@ -20,7 +20,8 @@
 				<div class="flex flex-row items-center gap-2">
 					<img
 						class="pixelated w-8"
-						src="https://mc-heads.net/avatar/{record.uuid}/8"
+						src="https://api.elitebot.dev/account/{record.uuid}/face.png"
+						loading="lazy"
 						alt="{record.ign} Player Head"
 					/>
 					<p class="font-semibold">{record.ign}</p>


### PR DESCRIPTION
Replaces all mc-heads.net use for player avatars, replacing it with the new elite face endpoint. This is probably going to be slower, but it renders hat overlays so that's cool.