### PR TITLE
Update GitHub link for SkyCrypt repository

### DIFF
--- a/src/content/credits.ts
+++ b/src/content/credits.ts
@@ -114,7 +114,7 @@ export const CREDITS: Credit[] = [
 		links: [
 			{
 				name: 'GitHub',
-				url: 'https://github.com/SkyCryptWebsite/SkyCrypt',
+				url: 'https://github.com/SkyCryptWebsite/SkyCryptv2',
 			},
 			{
 				name: 'Website',


### PR DESCRIPTION
Correct the GitHub link in the credits to point to the appropriate version of the SkyCrypt repository.