### PR TITLE
Implement Synthesis Bonus for mutation command

### DIFF
--- a/packages/farming-weight/src/constants/chips.ts
+++ b/packages/farming-weight/src/constants/chips.ts
@@ -57,6 +57,17 @@ export const GARDEN_CHIPS: Record<GardenChipId, GardenChipInfo> = {
 		skyblockId: 'SYNTHESIS_GARDEN_CHIP',
 		name: 'Synthesis Chip',
 		wiki: GARDEN_CHIP_WIKI,
+        statsPerRarity: {
+			[Rarity.Rare]: {
+				[Stat.BonusCopperPercentage]: 1,
+			},
+			[Rarity.Epic]: {
+				[Stat.BonusCopperPercentage]: 1.5,
+			},
+			[Rarity.Legendary]: {
+				[Stat.BonusCopperPercentage]: 2,
+			},
+		},
 	},
 	sowledge: {
 		skyblockId: 'SOWLEDGE_GARDEN_CHIP',

--- a/packages/farming-weight/src/constants/stats.ts
+++ b/packages/farming-weight/src/constants/stats.ts
@@ -40,6 +40,7 @@ export enum Stat {
 	BonusPestChance = 'Bonus Pest Chance',
 	PestCooldownReduction = 'Pest Cooldown Reduction',
 	FishingSpeed = 'Fishing Speed',
+    BonusCopperPercentage = 'Bonus Copper Percentage',
 }
 
 /**
@@ -216,4 +217,5 @@ export const STAT_NAMES: Record<Stat, string> = {
 	[Stat.BonusPestChance]: 'Bonus Pest Chance',
 	[Stat.PestCooldownReduction]: 'Pest Cooldown Reduction',
 	[Stat.FishingSpeed]: 'Fishing Speed',
+    [Stat.BonusCopperPercentage]: 'Bonus Copper Percentage',
 };


### PR DESCRIPTION
Implemented the Synthesis Bonus (named BonusCopperPercentage).

I need it for the mutation command (see the PR in the bot repository).

If you could make farmingweight accessible to the bot again, that would help a lot :)
Otherwise, I’ll hardcode the synthesis bonus based on rarity, but that feels less clean in my opinion.

(feel free to rename or ask me to changes the stat name)