### PR TITLE
Fix issues with pest farming page

### DIFF
--- a/packages/farming-weight/src/constants/attributes.ts
+++ b/packages/farming-weight/src/constants/attributes.ts
@@ -209,6 +209,11 @@ export const FARMING_ATTRIBUTE_SHARDS: Record<string, FarmingAttributeShard> = {
 		rarity: Rarity.Uncommon,
 		effect: 'rates',
 		wiki: 'https://w.elitesb.gg/Pest',
+		perLevelStats: {
+			[Stat.Overbloom]: {
+				value: 2,
+			},
+		},
 	},
 	visitor_bait: {
 		// Garden visitors 1% faster per level

--- a/packages/farming-weight/src/items/sources/attributes.test.ts
+++ b/packages/farming-weight/src/items/sources/attributes.test.ts
@@ -233,7 +233,7 @@ describe('GalaxyFishShard', () => {
 });
 
 describe('PestShard', () => {
-	test('emits pest-only Overbloom at level 1', () => {
+	test('emits pest-specific flat Overbloom at level 1', () => {
 		const player = createFarmingPlayer({ farmingLevel: 60, attributes: { pest_luck: 1 } });
 		const env = buildEffectEnvironment(player);
 		const effects = new PestShard().getEffects(player, env);
@@ -252,7 +252,7 @@ describe('PestShard', () => {
 		});
 	});
 
-	test('only buffs pest drops and reaches +20 at max level', () => {
+	test('only buffs pest drops and reaches +20 flat Overbloom at max level', () => {
 		const player = createFarmingPlayer({ farmingLevel: 60, attributes: { pest_luck: 999 } });
 		const env = buildEffectEnvironment(player);
 		const effects = new PestShard().getEffects(player, env);
@@ -260,7 +260,7 @@ describe('PestShard', () => {
 		const pest = dropCtx({
 			dropKind: 'pest',
 			itemId: 'PEST_DROP',
-			tags: new Set(['pest']),
+			tags: new Set(['pest', 'overbloom']),
 		});
 		const cropie = dropCtx({
 			itemId: 'CROPIE',

--- a/packages/farming-weight/src/pests/pest-farming-rate-calculator.test.ts
+++ b/packages/farming-weight/src/pests/pest-farming-rate-calculator.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from 'vitest';
 import { Crop } from '../constants/crops.js';
 import { Pest } from '../constants/pests.js';
+import { Rarity } from '../constants/reforges.js';
 import { Stat } from '../constants/stats.js';
+import type { EliteItemDto } from '../fortune/item.js';
+import { FARMING_ARMOR_INFO } from '../items/armor.js';
+import { GearSlot } from '../items/definitions.js';
 import { PestFarmingPhase, PestFarmingPlayer } from '../player/pestfarmingplayer.js';
 import type { DetailedDropsFromEffectsResult } from '../util/ratecalc-effects.js';
 import { calculatePestCropDropAmount, PEST_DROP_DEFINITIONS } from './pest-drops.js';
@@ -25,6 +29,83 @@ function emptyCropRates(blocksBroken = 0): DetailedDropsFromEffectsResult {
 		appliedEffects: {},
 		effectsBreakdown: {},
 	};
+}
+
+function armorItem(
+	id: keyof typeof FARMING_ARMOR_INFO,
+	uuid: string,
+	attributes: NonNullable<EliteItemDto['attributes']> = {}
+): EliteItemDto {
+	const info = FARMING_ARMOR_INFO[id]!;
+	return {
+		name: info.name,
+		skyblockId: info.skyblockId,
+		uuid,
+		lore: [],
+		attributes: {
+			rarity: Rarity.Legendary,
+			...attributes,
+		},
+		enchantments: {},
+		gems: {},
+	};
+}
+
+function mantidArmor(id: keyof typeof FARMING_ARMOR_INFO, uuid: string): EliteItemDto {
+	return armorItem(id, uuid, { modifier: 'mantid' });
+}
+
+function pestPlayerWithArmorSets(options: {
+	main: [
+		keyof typeof FARMING_ARMOR_INFO,
+		keyof typeof FARMING_ARMOR_INFO,
+		keyof typeof FARMING_ARMOR_INFO,
+		keyof typeof FARMING_ARMOR_INFO,
+	];
+	spawn: [
+		keyof typeof FARMING_ARMOR_INFO,
+		keyof typeof FARMING_ARMOR_INFO,
+		keyof typeof FARMING_ARMOR_INFO,
+		keyof typeof FARMING_ARMOR_INFO,
+	];
+}): PestFarmingPlayer {
+	const mainUuids = ['main-helmet', 'main-chestplate', 'main-leggings', 'main-boots'] as const;
+	const spawnUuids = ['spawn-helmet', 'spawn-chestplate', 'spawn-leggings', 'spawn-boots'] as const;
+
+	return new PestFarmingPlayer({
+		armor: [
+			armorItem(options.main[0], mainUuids[0]),
+			armorItem(options.main[1], mainUuids[1]),
+			armorItem(options.main[2], mainUuids[2]),
+			armorItem(options.main[3], mainUuids[3]),
+			armorItem(options.spawn[0], spawnUuids[0]),
+			armorItem(options.spawn[1], spawnUuids[1]),
+			armorItem(options.spawn[2], spawnUuids[2]),
+			armorItem(options.spawn[3], spawnUuids[3]),
+		],
+		armorSets: [
+			{
+				id: 'main',
+				name: 'Farm/Kill Armor',
+				pieces: {
+					[GearSlot.Helmet]: mainUuids[0],
+					[GearSlot.Chestplate]: mainUuids[1],
+					[GearSlot.Leggings]: mainUuids[2],
+					[GearSlot.Boots]: mainUuids[3],
+				},
+			},
+			{
+				id: 'spawn',
+				name: 'Spawn Armor',
+				pieces: {
+					[GearSlot.Helmet]: spawnUuids[0],
+					[GearSlot.Chestplate]: spawnUuids[1],
+					[GearSlot.Leggings]: spawnUuids[2],
+					[GearSlot.Boots]: spawnUuids[3],
+				},
+			},
+		],
+	});
 }
 
 test('pest crop drops use farming, associated crop, and pest kill fortune through scaling', () => {
@@ -114,6 +195,105 @@ test('bonus pest chance controls expected pests per spawn', () => {
 	expect(result.perInterval.npcCoins).toBeGreaterThan(0);
 });
 
+test('selected crop does not bias pest type spawn weights', () => {
+	const player = new PestFarmingPlayer({});
+	const getProbabilities = (crop: Crop) =>
+		new PestFarmingRateCalculator({
+			player,
+			options: {
+				crop,
+				cycle: DEFAULT_PEST_CYCLE_SETTINGS,
+			},
+		}).calculate().breakdown.pestSpawning.distribution.pestTypeProbabilities;
+
+	expect(getProbabilities(Crop.Wheat)).toEqual(getProbabilities(Crop.Potato));
+});
+
+test('best spawn phase armor set uses rate calculation to select the generated spawn set when it improves rates', () => {
+	const player = pestPlayerWithArmorSets({
+		main: ['FERMENTO_HELMET', 'FERMENTO_CHESTPLATE', 'FERMENTO_LEGGINGS', 'FERMENTO_BOOTS'],
+		spawn: ['HELIANTHUS_HELMET', 'HELIANTHUS_CHESTPLATE', 'HELIANTHUS_LEGGINGS', 'HELIANTHUS_BOOTS'],
+	});
+	const calculator = new PestFarmingRateCalculator({
+		player,
+		options: {
+			crop: Crop.Wheat,
+			cycle: DEFAULT_PEST_CYCLE_SETTINGS,
+		},
+	});
+
+	expect(calculator.getBestSpawnPhaseArmorSetId(['main', 'spawn'])).toBe('spawn');
+});
+
+test('best spawn phase armor set uses rate calculation to reuse main armor when the spawn set is worse', () => {
+	const player = pestPlayerWithArmorSets({
+		main: ['HELIANTHUS_HELMET', 'HELIANTHUS_CHESTPLATE', 'HELIANTHUS_LEGGINGS', 'HELIANTHUS_BOOTS'],
+		spawn: ['CROPIE_HELMET', 'CROPIE_CHESTPLATE', 'CROPIE_LEGGINGS', 'CROPIE_BOOTS'],
+	});
+	const calculator = new PestFarmingRateCalculator({
+		player,
+		options: {
+			crop: Crop.Wheat,
+			cycle: DEFAULT_PEST_CYCLE_SETTINGS,
+		},
+	});
+
+	expect(calculator.getBestSpawnPhaseArmorSetId(['main', 'spawn'])).toBe('main');
+});
+
+test('rate calculation can automatically use the best spawn armor candidate', () => {
+	const player = pestPlayerWithArmorSets({
+		main: ['HELIANTHUS_HELMET', 'HELIANTHUS_CHESTPLATE', 'HELIANTHUS_LEGGINGS', 'HELIANTHUS_BOOTS'],
+		spawn: ['CROPIE_HELMET', 'CROPIE_CHESTPLATE', 'CROPIE_LEGGINGS', 'CROPIE_BOOTS'],
+	});
+	const rawSpawnBonusPestChance = player.getPhaseStat(PestFarmingPhase.Spawn, Stat.BonusPestChance);
+	const mainSelected = player.clone();
+	mainSelected.setPhaseArmorSet(PestFarmingPhase.Spawn, 'main');
+	const mainSpawnBonusPestChance = mainSelected.getPhaseStat(PestFarmingPhase.Spawn, Stat.BonusPestChance);
+
+	const result = new PestFarmingRateCalculator({
+		player,
+		options: {
+			crop: Crop.Wheat,
+			cycle: DEFAULT_PEST_CYCLE_SETTINGS,
+		},
+		armorSelection: {
+			spawnArmorSetIds: ['main', 'spawn'],
+		},
+	}).calculate();
+
+	expect(rawSpawnBonusPestChance).toBeLessThan(mainSpawnBonusPestChance);
+	expect(result.phaseStats.spawnBonusPestChance).toBe(mainSpawnBonusPestChance);
+});
+
+test('pest rate calculation derives Mantid recent pest kills from expected spawned pests', () => {
+	const player = new PestFarmingPlayer({
+		armor: [
+			mantidArmor('HELIANTHUS_HELMET', 'mantid-helmet'),
+			mantidArmor('HELIANTHUS_CHESTPLATE', 'mantid-chestplate'),
+			mantidArmor('HELIANTHUS_LEGGINGS', 'mantid-leggings'),
+			mantidArmor('HELIANTHUS_BOOTS', 'mantid-boots'),
+		],
+	});
+	const baseBonusPestChance = player.getPhaseStat(PestFarmingPhase.Spawn, Stat.BonusPestChance);
+	const expectedResolvedBonusPestChance = (baseBonusPestChance + 1) / 0.99;
+	const expectedPestsPerSpawn = 1 + expectedResolvedBonusPestChance / 100;
+
+	const result = new PestFarmingRateCalculator({
+		player,
+		options: {
+			crop: Crop.Wheat,
+			cycle: DEFAULT_PEST_CYCLE_SETTINGS,
+		},
+	}).calculate();
+
+	expect(player.options.mantidPestKills).toBeUndefined();
+	expect(baseBonusPestChance).toBe(88);
+	expect(result.phaseStats.spawnBonusPestChance).toBeGreaterThan(baseBonusPestChance);
+	expect(result.phaseStats.spawnBonusPestChance).toBeCloseTo(expectedResolvedBonusPestChance, 6);
+	expect(result.breakdown.pestSpawning.expectedPestsPerSpawn).toBeCloseTo(expectedPestsPerSpawn, 6);
+});
+
 test('spawn phase bonus pest chance upgrades report positive pest rate impact', () => {
 	const player = new PestFarmingPlayer({
 		wrigglingLarva: 0,
@@ -146,6 +326,51 @@ test('spawn phase bonus pest chance upgrades report positive pest rate impact', 
 
 	expect(impact.delta.expectedPestsPerCycle).toBeGreaterThan(0);
 	expect(impact.valuationDelta.coinsPerHour).toBeGreaterThan(0);
+});
+
+test('upgrade impact completeness is based on missing delta prices', () => {
+	const player = new PestFarmingPlayer({
+		selectedCrop: Crop.Wheat,
+	});
+	const calculator = new PestFarmingRateCalculator({
+		player,
+		options: {
+			crop: Crop.Wheat,
+			cycle: DEFAULT_PEST_CYCLE_SETTINGS,
+		},
+		priceBook: {
+			version: 'test',
+			items: {},
+			missingItemMode: 'exclude',
+		},
+	});
+	const before = calculator.calculate();
+	const noDeltaUpgrade = player
+		.getPhaseUpgrades(PestFarmingPhase.Farm, { includeUpgradeGroups: true })
+		.find((entry) => entry.title === 'Atmospheric Filter');
+	const cropDeltaUpgrade = player
+		.getPhaseUpgrades(PestFarmingPhase.Farm, { includeUpgradeGroups: true })
+		.find((entry) => entry.title === 'Farm Armor Helmet');
+
+	expect(before.valuation.complete).toBe(false);
+	expect(noDeltaUpgrade).toBeDefined();
+	expect(cropDeltaUpgrade).toBeDefined();
+
+	const noDeltaImpact = calculator.calculateUpgradeImpact({
+		phase: PestFarmingPhase.Farm,
+		upgrade: noDeltaUpgrade!,
+		before,
+	});
+	const cropDeltaImpact = calculator.calculateUpgradeImpact({
+		phase: PestFarmingPhase.Farm,
+		upgrade: cropDeltaUpgrade!,
+		before,
+	});
+
+	expect(noDeltaImpact.valuationDelta.complete).toBe(true);
+	expect(noDeltaImpact.valuationDelta.missingItemIds).toEqual([]);
+	expect(cropDeltaImpact.valuationDelta.complete).toBe(false);
+	expect(cropDeltaImpact.valuationDelta.missingItemIds).toContain(Crop.Wheat);
 });
 
 test('crop breaking does not double count crop item NPC valuation', () => {

--- a/packages/farming-weight/src/pests/pest-farming-rate-calculator.ts
+++ b/packages/farming-weight/src/pests/pest-farming-rate-calculator.ts
@@ -19,6 +19,7 @@ import type {
 	PestCycleDebug,
 	PestCycleSettings,
 	PestEconomySettings,
+	PestFarmingRateArmorSelection,
 	PestFarmingRateCalculatorInput,
 	PestFarmingRateDelta,
 	PestFarmingRateOptions,
@@ -39,6 +40,9 @@ const SPRAYED_PLOT_SPAWN_MULTIPLIER = 2;
 const ATMOSPHERIC_FILTER_SPAWN_MULTIPLIER = 1.15;
 const DEFAULT_PEST_MAX_ACTIVE = 8;
 const PEST_RARE_DROP_FORTUNE_SCALING = 600;
+const MANTID_RECENT_KILL_CAP = 20;
+const MANTID_RESOLUTION_ITERATIONS = 8;
+const MANTID_RESOLUTION_EPSILON = 1e-6;
 
 type PestDropCalculationContext = {
 	farmingFortune: number;
@@ -71,7 +75,10 @@ export class PestFarmingRateCalculator {
 	readonly player: PestFarmingPlayer;
 	readonly options: PestFarmingRateOptions;
 	readonly priceBook: PestRatePriceBook;
+	readonly armorSelection?: PestFarmingRateArmorSelection;
 	private phaseStats?: PestRatePhaseStats;
+	private calculationPlayer?: PestFarmingPlayer;
+	private resolvedMantidPestKills?: number;
 
 	constructor(input: PestFarmingRateCalculatorInput) {
 		this.player = input.player;
@@ -81,17 +88,19 @@ export class PestFarmingRateCalculator {
 			cycle: normalizeCycleSettings(input.options.cycle),
 		};
 		this.priceBook = input.priceBook ?? { version: 'empty', missingItemMode: 'exclude' };
+		this.armorSelection = input.armorSelection;
 	}
 
 	calculate(): PestFarmingRateResult {
 		const phaseStats = this.getPhaseStats();
+		const player = this.getCalculationPlayer();
 		const stateKey = this.getStateKey(phaseStats);
 		const spawnDistribution = this.getSpawnDistribution(phaseStats.spawnBonusPestChance);
 		const debug = this.getCycleDebug(phaseStats, spawnDistribution.expectedPestsPerSpawn);
-		const farmCrop = this.player.crop.getRates(this.options.crop, debug.farmBlocks);
-		const spawnCrop = this.player.spawn.getRates(this.options.crop, debug.spawnBlocks);
+		const farmCrop = player.crop.getRates(this.options.crop, debug.farmBlocks);
+		const spawnCrop = player.spawn.getRates(this.options.crop, debug.spawnBlocks);
 		const cropBreaking = sumCropRateResults([farmCrop, spawnCrop]);
-		const pestDrops = this.calculatePestDrops(spawnDistribution, phaseStats);
+		const pestDrops = this.calculatePestDrops(spawnDistribution, phaseStats, player);
 		const intervalScale = (this.options.intervalSeconds ?? DEFAULT_INTERVAL_SECONDS) / debug.cycleSeconds;
 		const economy = this.calculateEconomy(spawnDistribution.expectedPestsPerSpawn, debug, intervalScale);
 		const perCycle = sumQuantities(
@@ -151,7 +160,13 @@ export class PestFarmingRateCalculator {
 		cloned.applyPhaseUpgrade(request.phase, request.upgrade);
 		const after = this.withPlayer(cloned).calculate();
 		const delta = diffPestRateResults(before, after);
-		const valuationDelta = diffValuation(before.valuation, after.valuation, request.upgradeCostCoins);
+		const valuationDelta = diffValuation(
+			before.valuation,
+			after.valuation,
+			this.getMissingDeltaItemIds(delta),
+			this.getMissingDeltaCurrencyIds(delta),
+			request.upgradeCostCoins
+		);
 
 		return {
 			phase: request.phase,
@@ -164,13 +179,17 @@ export class PestFarmingRateCalculator {
 	}
 
 	getStateKey(phaseStats = this.getPhaseStats()): string {
+		const player = this.getCalculationPlayer();
 		return stableValueKey({
 			options: this.options,
 			phaseStats,
 			phaseLoadouts: this.player.phaseLoadouts,
+			effectivePhaseLoadouts: player.phaseLoadouts,
 			armorSets: this.player.armorSetLoadouts,
 			sharedEquipment: this.player.sharedEquipment,
 			selectedVacuum: this.player.selectedVacuum?.item,
+			armorSelection: this.armorSelection,
+			resolvedMantidPestKills: this.resolvedMantidPestKills,
 			priceBook: {
 				version: this.priceBook.version,
 				missingItemMode: this.priceBook.missingItemMode,
@@ -190,31 +209,170 @@ export class PestFarmingRateCalculator {
 	}
 
 	withPlayer(player: PestFarmingPlayer): PestFarmingRateCalculator {
-		return new PestFarmingRateCalculator({ player, options: this.options, priceBook: this.priceBook });
+		return new PestFarmingRateCalculator({
+			player,
+			options: this.options,
+			priceBook: this.priceBook,
+			armorSelection: this.armorSelection,
+		});
 	}
 
 	withOptions(options: PestFarmingRateOptions): PestFarmingRateCalculator {
-		return new PestFarmingRateCalculator({ player: this.player, options, priceBook: this.priceBook });
+		return new PestFarmingRateCalculator({
+			player: this.player,
+			options,
+			priceBook: this.priceBook,
+			armorSelection: this.armorSelection,
+		});
 	}
 
 	withPriceBook(priceBook: PestRatePriceBook): PestFarmingRateCalculator {
-		return new PestFarmingRateCalculator({ player: this.player, options: this.options, priceBook });
+		return new PestFarmingRateCalculator({
+			player: this.player,
+			options: this.options,
+			priceBook,
+			armorSelection: this.armorSelection,
+		});
+	}
+
+	getBestSpawnPhaseArmorSetId(armorSetIds: readonly string[]): string | undefined {
+		const candidates = uniqueValidArmorSetIds(this.player, armorSetIds);
+		if (candidates.length === 0) return undefined;
+
+		let bestId = candidates[0]!;
+		let bestRate = this.calculateSpawnArmorSetRate(bestId);
+		for (const armorSetId of candidates.slice(1)) {
+			const rate = this.calculateSpawnArmorSetRate(armorSetId);
+			if (rate > bestRate) {
+				bestId = armorSetId;
+				bestRate = rate;
+			}
+		}
+		return bestId;
+	}
+
+	private calculateSpawnArmorSetRate(armorSetId: string): number {
+		const player = this.player.clone();
+		player.setPhaseArmorSet(PestFarmingPhase.Spawn, armorSetId);
+		const rate = new PestFarmingRateCalculator({
+			player,
+			options: this.options,
+			priceBook: this.priceBook,
+		}).calculate().valuation.coinsPerHour;
+		return Number.isFinite(rate) ? rate : Number.NEGATIVE_INFINITY;
+	}
+
+	private getCalculationPlayer(): PestFarmingPlayer {
+		if (this.calculationPlayer) return this.calculationPlayer;
+		this.calculationPlayer = this.resolveMantidPlayer(this.resolveSpawnArmorSelectionPlayer(this.player));
+		return this.calculationPlayer;
+	}
+
+	private resolveSpawnArmorSelectionPlayer(player: PestFarmingPlayer): PestFarmingPlayer {
+		const candidates = uniqueValidArmorSetIds(player, this.armorSelection?.spawnArmorSetIds ?? []);
+		if (candidates.length === 0) return player;
+
+		let bestId = candidates[0]!;
+		let bestRate = this.calculateSpawnArmorSetRateForPlayer(player, bestId);
+		for (const armorSetId of candidates.slice(1)) {
+			const rate = this.calculateSpawnArmorSetRateForPlayer(player, armorSetId);
+			if (rate > bestRate) {
+				bestId = armorSetId;
+				bestRate = rate;
+			}
+		}
+
+		if (player.phaseLoadouts[PestFarmingPhase.Spawn]?.armorSetId === bestId) return player;
+
+		const selected = player.clone();
+		selected.setPhaseArmorSet(PestFarmingPhase.Spawn, bestId);
+		return selected;
+	}
+
+	private calculateSpawnArmorSetRateForPlayer(player: PestFarmingPlayer, armorSetId: string): number {
+		const selected = player.clone();
+		selected.setPhaseArmorSet(PestFarmingPhase.Spawn, armorSetId);
+		const rate = new PestFarmingRateCalculator({
+			player: selected,
+			options: this.options,
+			priceBook: this.priceBook,
+		}).calculate().valuation.coinsPerHour;
+		return Number.isFinite(rate) ? rate : Number.NEGATIVE_INFINITY;
+	}
+
+	private resolveMantidPlayer(player: PestFarmingPlayer): PestFarmingPlayer {
+		this.resolvedMantidPestKills = normalizeMantidRecentPestKills(player.options?.mantidPestKills ?? 0);
+		if (!this.hasMantidSpawnArmor(player) || typeof player.clone !== 'function') return player;
+
+		let recentKills = 0;
+		let resolved = this.clonePlayerWithMantidPestKills(player, recentKills);
+		for (let iteration = 0; iteration < MANTID_RESOLUTION_ITERATIONS; iteration++) {
+			const spawnBonusPestChance = resolved.getPhaseStat(PestFarmingPhase.Spawn, Stat.BonusPestChance);
+			const nextRecentKills = normalizeMantidRecentPestKills(
+				this.getSpawnDistribution(spawnBonusPestChance).expectedPestsPerSpawn
+			);
+			if (Math.abs(nextRecentKills - recentKills) < MANTID_RESOLUTION_EPSILON) {
+				this.resolvedMantidPestKills = recentKills;
+				return resolved;
+			}
+
+			recentKills = nextRecentKills;
+			resolved = this.clonePlayerWithMantidPestKills(player, recentKills);
+		}
+
+		this.resolvedMantidPestKills = recentKills;
+		return resolved;
+	}
+
+	private hasMantidSpawnArmor(player: PestFarmingPlayer): boolean {
+		if (typeof player.getPhaseArmorSet !== 'function') return false;
+		return player
+			.getPhaseArmorSet(PestFarmingPhase.Spawn)
+			.armor.some((piece) => piece?.item.attributes?.modifier === 'mantid');
+	}
+
+	private clonePlayerWithMantidPestKills(player: PestFarmingPlayer, kills: number): PestFarmingPlayer {
+		const resolved = player.clone();
+		resolved.setOptions({
+			...resolved.options,
+			mantidPestKills: kills,
+		});
+		return resolved;
+	}
+
+	private getMissingDeltaItemIds(delta: PestFarmingRateDelta): string[] {
+		if (this.priceBook.missingItemMode === 'zero') return [];
+
+		const ids = new Set<string>();
+		for (const itemId of [...Object.keys(delta.items), ...Object.keys(delta.rngItems)]) {
+			if (!this.priceBook.items?.[itemId]) ids.add(itemId);
+		}
+		return [...ids];
+	}
+
+	private getMissingDeltaCurrencyIds(delta: PestFarmingRateDelta): string[] {
+		if (this.priceBook.missingItemMode === 'zero') return [];
+
+		return Object.keys(delta.currencies).filter(
+			(currencyId) => this.priceBook.currencies?.[currencyId] === undefined
+		);
 	}
 
 	private getPhaseStats(): PestRatePhaseStats {
 		if (this.phaseStats) return this.phaseStats;
 
+		const player = this.getCalculationPlayer();
 		const associatedCropFortune = Object.fromEntries(
-			Object.values(Crop).map((crop) => [crop, getAssociatedCropFortune(this.player.kill, crop)])
+			Object.values(Crop).map((crop) => [crop, getAssociatedCropFortune(player.kill, crop)])
 		) as Partial<Record<Crop, number>>;
 
 		this.phaseStats = {
-			farmPestCooldownReduction: this.player.getPhaseStat(PestFarmingPhase.Farm, Stat.PestCooldownReduction),
-			spawnBonusPestChance: this.player.getPhaseStat(PestFarmingPhase.Spawn, Stat.BonusPestChance),
-			killFarmingFortune: this.player.getPhaseStat(PestFarmingPhase.Kill, Stat.FarmingFortune),
-			killPestKillFortune: this.player.getPhaseStat(PestFarmingPhase.Kill, Stat.PestKillFortune),
-			killOverbloom: this.player.getPhaseStat(PestFarmingPhase.Kill, Stat.Overbloom),
-			killDamage: this.player.getPhaseStat(PestFarmingPhase.Kill, Stat.Damage),
+			farmPestCooldownReduction: player.getPhaseStat(PestFarmingPhase.Farm, Stat.PestCooldownReduction),
+			spawnBonusPestChance: player.getPhaseStat(PestFarmingPhase.Spawn, Stat.BonusPestChance),
+			killFarmingFortune: player.getPhaseStat(PestFarmingPhase.Kill, Stat.FarmingFortune),
+			killPestKillFortune: player.getPhaseStat(PestFarmingPhase.Kill, Stat.PestKillFortune),
+			killOverbloom: player.getPhaseStat(PestFarmingPhase.Kill, Stat.Overbloom),
+			killDamage: player.getPhaseStat(PestFarmingPhase.Kill, Stat.Damage),
 			associatedCropFortune,
 		};
 		return this.phaseStats;
@@ -303,7 +461,8 @@ export class PestFarmingRateCalculator {
 
 	private calculatePestDrops(
 		spawnDistribution: PestSpawnDistribution,
-		phaseStats = this.getPhaseStats()
+		phaseStats = this.getPhaseStats(),
+		player = this.getCalculationPlayer()
 	): {
 		byPest: Partial<Record<Pest, DetailedPestDropsResult>>;
 		total: PestRateQuantities;
@@ -316,7 +475,7 @@ export class PestFarmingRateCalculator {
 			if (expectedPests <= 0) continue;
 			const definition = PEST_DROP_DEFINITIONS[pest];
 			if (!definition) continue;
-			context ??= this.createPestDropCalculationContext(phaseStats);
+			context ??= this.createPestDropCalculationContext(phaseStats, player);
 			byPest[pest] = this.calculateDropsForPest(definition, expectedPests, context);
 		}
 
@@ -326,13 +485,16 @@ export class PestFarmingRateCalculator {
 		};
 	}
 
-	private createPestDropCalculationContext(phaseStats: PestRatePhaseStats): PestDropCalculationContext {
-		const kill = this.player.kill;
+	private createPestDropCalculationContext(
+		phaseStats: PestRatePhaseStats,
+		player = this.getCalculationPlayer()
+	): PestDropCalculationContext {
+		const kill = player.kill;
 		const env = kill.buildEnvironment(this.options.crop);
 		return {
 			farmingFortune: phaseStats.killFarmingFortune,
 			pestKillFortune: phaseStats.killPestKillFortune,
-			petLuck: this.player.getPhaseStat(PestFarmingPhase.Kill, Stat.PetLuck),
+			petLuck: player.getPhaseStat(PestFarmingPhase.Kill, Stat.PetLuck),
 			associatedCropFortune: phaseStats.associatedCropFortune,
 			env,
 			effects: kill.collectEffects(env),
@@ -621,6 +783,10 @@ function emptyQuantities(): PestRateQuantities {
 	};
 }
 
+function normalizeMantidRecentPestKills(kills: number): number {
+	return Number.isFinite(kills) ? Math.max(0, Math.min(MANTID_RECENT_KILL_CAP, kills)) : 0;
+}
+
 function valueQuantities(
 	quantity: PestRateQuantities,
 	priceBook: PestRatePriceBook,
@@ -684,25 +850,26 @@ function diffPestRateResults(before: PestFarmingRateResult, after: PestFarmingRa
 function diffValuation(
 	before: PestRateValuationResult,
 	after: PestRateValuationResult,
+	missingItemIds: string[],
+	missingCurrencyIds: string[],
 	upgradeCostCoins?: number
 ): PestRateValuationDelta {
 	const coinsPerHour = after.coinsPerHour - before.coinsPerHour;
 	return {
-		complete: before.complete && after.complete,
+		complete: missingItemIds.length === 0 && missingCurrencyIds.length === 0,
 		coinsPerCycle: after.coinsPerCycle - before.coinsPerCycle,
 		coinsPerInterval: after.coinsPerInterval - before.coinsPerInterval,
 		coinsPerHour,
 		costPerCoinsPerHour:
 			upgradeCostCoins !== undefined && coinsPerHour > 0 ? upgradeCostCoins / coinsPerHour : undefined,
-		missingItemIds: [...new Set([...before.missingItemIds, ...after.missingItemIds])],
+		missingItemIds,
+		missingCurrencyIds,
 	};
 }
 
 function getPestTypeWeights(attraction?: PestAttractionSettings): Partial<Record<Pest, number>> {
 	const pests = attraction?.includeSpecialPests ? [...NATURAL_PESTS, Pest.Mouse, Pest.LunarMoth] : NATURAL_PESTS;
 	const weights: Partial<Record<Pest, number>> = Object.fromEntries(pests.map((pest) => [pest, 1]));
-	if (attraction?.selectedPest && weights[attraction.selectedPest] !== undefined)
-		weights[attraction.selectedPest] = 12;
 	if (attraction?.sprayonatorTarget && weights[attraction.sprayonatorTarget] !== undefined) {
 		weights[attraction.sprayonatorTarget] = (weights[attraction.sprayonatorTarget] ?? 1) * 12;
 	}
@@ -750,6 +917,17 @@ function sumRecord(record: Record<string, number> | Partial<Record<Crop, number>
 function addRecord<T extends string>(record: Partial<Record<T, number>>, key: T, value: number): void {
 	if (!value) return;
 	record[key] = (record[key] ?? 0) + value;
+}
+
+function uniqueValidArmorSetIds(player: PestFarmingPlayer, armorSetIds: readonly string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const armorSetId of armorSetIds) {
+		if (seen.has(armorSetId) || !player.getArmorSetLoadout(armorSetId)) continue;
+		seen.add(armorSetId);
+		result.push(armorSetId);
+	}
+	return result;
 }
 
 function getUpgradeIdentity(upgrade: FortuneUpgrade): string {

--- a/packages/farming-weight/src/pests/pest-rate-types.ts
+++ b/packages/farming-weight/src/pests/pest-rate-types.ts
@@ -27,7 +27,6 @@ export interface PestCycleSettings {
 }
 
 export interface PestAttractionSettings {
-	selectedPest?: Pest;
 	sprayonatorTarget?: Pest;
 	hooveriusVinylTarget?: Pest;
 	hooveriusVinylMultiplier?: number;
@@ -83,10 +82,15 @@ export interface PestRatePriceBook {
 	missingItemMode?: 'exclude' | 'zero';
 }
 
+export interface PestFarmingRateArmorSelection {
+	spawnArmorSetIds?: readonly string[];
+}
+
 export interface PestFarmingRateCalculatorInput {
 	player: PestFarmingPlayer;
 	options: PestFarmingRateOptions;
 	priceBook?: PestRatePriceBook;
+	armorSelection?: PestFarmingRateArmorSelection;
 }
 
 export interface PestCycleDebug {
@@ -221,6 +225,7 @@ export interface PestRateValuationDelta {
 	coinsPerHour: number;
 	costPerCoinsPerHour?: number;
 	missingItemIds: string[];
+	missingCurrencyIds: string[];
 }
 
 export interface PestFarmingUpgradeRateImpact

--- a/packages/farming-weight/src/player/pestfarmingplayer.test.ts
+++ b/packages/farming-weight/src/player/pestfarmingplayer.test.ts
@@ -154,6 +154,86 @@ test('default pest armor loadouts prefer equipped and separate wardrobe sets bef
 	expect(player.getPhaseArmorSet(PestFarmingPhase.Spawn).helmet?.item.uuid).toBe('spawn-helmet');
 });
 
+test('default spawn phase uses the separate armor set when available', () => {
+	const player = new PestFarmingPlayer({
+		armor: [
+			armor('FERMENTO_HELMET', 'main-helmet'),
+			armor('FERMENTO_CHESTPLATE', 'main-chestplate'),
+			armor('FERMENTO_LEGGINGS', 'main-leggings'),
+			armor('FERMENTO_BOOTS', 'main-boots'),
+			armor('HELIANTHUS_HELMET', 'spawn-helmet'),
+			armor('HELIANTHUS_CHESTPLATE', 'spawn-chestplate'),
+			armor('HELIANTHUS_LEGGINGS', 'spawn-leggings'),
+			armor('HELIANTHUS_BOOTS', 'spawn-boots'),
+		],
+		armorSets: [
+			{
+				id: 'main',
+				name: 'Main Armor',
+				pieces: {
+					[GearSlot.Helmet]: 'main-helmet',
+					[GearSlot.Chestplate]: 'main-chestplate',
+					[GearSlot.Leggings]: 'main-leggings',
+					[GearSlot.Boots]: 'main-boots',
+				},
+			},
+			{
+				id: 'spawn',
+				name: 'Spawn Armor',
+				pieces: {
+					[GearSlot.Helmet]: 'spawn-helmet',
+					[GearSlot.Chestplate]: 'spawn-chestplate',
+					[GearSlot.Leggings]: 'spawn-leggings',
+					[GearSlot.Boots]: 'spawn-boots',
+				},
+			},
+		],
+	});
+
+	expect(player.phaseLoadouts[PestFarmingPhase.Spawn].armorSetId).toBe('spawn');
+	expect(player.getPhaseArmorSet(PestFarmingPhase.Spawn).helmet?.item.uuid).toBe('spawn-helmet');
+});
+
+test('default spawn phase keeps the generated spawn armor set as a rate-selection candidate', () => {
+	const player = new PestFarmingPlayer({
+		armor: [
+			armor('FERMENTO_HELMET', 'main-helmet'),
+			armor('FERMENTO_CHESTPLATE', 'main-chestplate'),
+			armor('FERMENTO_LEGGINGS', 'main-leggings'),
+			armor('FERMENTO_BOOTS', 'main-boots'),
+			armor('CROPIE_HELMET', 'spawn-helmet'),
+			armor('CROPIE_CHESTPLATE', 'spawn-chestplate'),
+			armor('CROPIE_LEGGINGS', 'spawn-leggings'),
+			armor('CROPIE_BOOTS', 'spawn-boots'),
+		],
+		armorSets: [
+			{
+				id: 'main',
+				name: 'Main Armor',
+				pieces: {
+					[GearSlot.Helmet]: 'main-helmet',
+					[GearSlot.Chestplate]: 'main-chestplate',
+					[GearSlot.Leggings]: 'main-leggings',
+					[GearSlot.Boots]: 'main-boots',
+				},
+			},
+			{
+				id: 'spawn',
+				name: 'Spawn Armor',
+				pieces: {
+					[GearSlot.Helmet]: 'spawn-helmet',
+					[GearSlot.Chestplate]: 'spawn-chestplate',
+					[GearSlot.Leggings]: 'spawn-leggings',
+					[GearSlot.Boots]: 'spawn-boots',
+				},
+			},
+		],
+	});
+
+	expect(player.phaseLoadouts[PestFarmingPhase.Spawn].armorSetId).toBe('spawn');
+	expect(player.getPhaseArmorSet(PestFarmingPhase.Spawn).helmet?.item.uuid).toBe('spawn-helmet');
+});
+
 test('phase armor and shared equipment progress are scoped to their loadout types', () => {
 	const player = new PestFarmingPlayer({
 		armor: [armor('HELIANTHUS_HELMET', 'main-helmet')],

--- a/packages/farming-weight/src/player/pestfarmingplayer.ts
+++ b/packages/farming-weight/src/player/pestfarmingplayer.ts
@@ -285,7 +285,7 @@ export class PestFarmingPlayer {
 	): Record<PestFarmingPhase, PestPhaseLoadout> {
 		const mainId = this.armorSetLoadouts[0]?.id ?? PEST_MAIN_ARMOR_SET_ID;
 		const spawnSet = this.armorSetLoadouts.find((set) => set.id === PEST_SPAWN_ARMOR_SET_ID);
-		const defaultSpawnId = hasArmorPieces(spawnSet) ? PEST_SPAWN_ARMOR_SET_ID : mainId;
+		const defaultSpawnId = spawnSet && hasArmorPieces(spawnSet) ? spawnSet.id : mainId;
 
 		return Object.fromEntries(
 			PEST_FARMING_PHASES.map((phase) => {

--- a/packages/farming-weight/src/upgrades/sources/generalsources.test.ts
+++ b/packages/farming-weight/src/upgrades/sources/generalsources.test.ts
@@ -145,8 +145,8 @@ test('Cropeetle shard surfaces Overbloom progress and upgrade under Attribute Sh
 
 	expect(attributeShards?.stats?.[Stat.Overbloom]).toMatchObject({
 		current: 5,
-		max: 10,
-		ratio: 0.5,
+		max: 30,
+		ratio: 5 / 30,
 	});
 	expect(attributeShards?.effects).toContainEqual(
 		expect.objectContaining({
@@ -206,6 +206,54 @@ test('Cropeetle shard surfaces Overbloom progress and upgrade under Attribute Sh
 	// Should NOT appear in plain FarmingFortune upgrades (no FF impact).
 	const ffUpgrades = player.getUpgrades({ stat: Stat.FarmingFortune });
 	expect(ffUpgrades.find((u) => u.title === 'Cropeetle 6')).toBeUndefined();
+});
+
+test('Pest shard surfaces pest-specific flat Overbloom progress under Attribute Shards', () => {
+	const player = new FarmingPlayer({
+		attributes: { pest_luck: 15 },
+	});
+
+	const progress = player.getProgress([Stat.FarmingFortune, Stat.Overbloom]);
+	const attributeShards = progress.find((p) => p.name === 'Attribute Shards');
+	const pestShard = attributeShards?.progress?.find((p) => p.name === 'Pest Shard');
+
+	expect(attributeShards?.stats?.[Stat.Overbloom]).toMatchObject({
+		current: 10,
+		max: 30,
+		ratio: 10 / 30,
+	});
+	expect(pestShard?.stats?.[Stat.Overbloom]).toMatchObject({
+		current: 10,
+		max: 20,
+		ratio: 0.5,
+	});
+	expect(pestShard?.effects).toContainEqual(
+		expect.objectContaining({
+			source: 'Pest Shard',
+			op: 'add-rare-pct',
+			value: 10,
+			scope: { tags: ['pest'] },
+			description: 'Pest Overbloom',
+			relatedStats: [Stat.Overbloom],
+			valueDisplay: 'stat',
+			valueStat: Stat.Overbloom,
+		})
+	);
+});
+
+test('progress-only garden chips show one nested progress bar', () => {
+	const player = new FarmingPlayer({
+		chips: { synthesis: 4, cropshot: 4 },
+	});
+
+	const chips = player.getProgress([Stat.FarmingFortune, Stat.Overbloom]).find((p) => p.name === 'Garden Chips');
+	const synthesis = chips?.progress?.find((p) => p.name === 'Synthesis Chip');
+	const cropshot = chips?.progress?.find((p) => p.name === 'Cropshot Chip');
+
+	expect(synthesis?.stats).toBeUndefined();
+	expect(synthesis?.progress?.map((p) => p.name)).toStrictEqual(['Level']);
+	expect(cropshot?.stats?.[Stat.FarmingFortune]).toBeDefined();
+	expect(cropshot?.progress?.map((p) => p.name)).toStrictEqual(['Level', 'Rarity']);
 });
 
 test('Freshly Baked Talisman purchase costs 25 kernels', () => {

--- a/packages/farming-weight/src/upgrades/sources/generalsources.ts
+++ b/packages/farming-weight/src/upgrades/sources/generalsources.ts
@@ -1334,20 +1334,25 @@ function mapChipSource(chipId: keyof typeof GARDEN_CHIPS, chip: GardenChipInfo):
 			const level = getChipLevel(player.options.chips?.[chipId]);
 			const rarity = getChipRarity(level, getChipInputRarity(player.options.chipRarities, chipId));
 			const maxLevel = getChipMaxLevelForRarity(rarity);
-			return [
+			const progress = [
 				{
 					name: 'Level',
 					current: level,
 					max: maxLevel,
 					ratio: Math.min(isNaN(level / maxLevel) ? 0 : level / maxLevel, 1),
 				},
-				{
+			];
+
+			if (chip.statsPerRarity) {
+				progress.push({
 					name: 'Rarity',
 					current: GARDEN_CHIP_RARITY_MAX_LEVELS[rarity],
 					max: GARDEN_CHIP_MAX_LEVEL,
 					ratio: GARDEN_CHIP_RARITY_MAX_LEVELS[rarity] / GARDEN_CHIP_MAX_LEVEL,
-				},
-			];
+				});
+			}
+
+			return progress;
 		},
 		upgrades: (player, stats) => {
 			const currentLevel = getChipLevel(player.options.chips?.[chipId]);

--- a/src/components/rates/effect-summary-list.svelte
+++ b/src/components/rates/effect-summary-list.svelte
@@ -18,6 +18,9 @@
 			const percent = (effect.value - 1) * 100;
 			return `${percent > 0 ? '+' : ''}${(+percent.toFixed(2)).toLocaleString()}%`;
 		}
+		if (effect.valueDisplay === 'stat') {
+			return `${effect.value > 0 ? '+' : ''}${(+effect.value.toFixed(2)).toLocaleString()}`;
+		}
 		if (effect.op === 'add-rare-pct') {
 			return `+${(+effect.value.toFixed(2)).toLocaleString()}%`;
 		}

--- a/src/lib/stores/ratesData.ts
+++ b/src/lib/stores/ratesData.ts
@@ -20,10 +20,9 @@ export type PestFarmingTimeOfDay = 'day' | 'night';
 
 export interface PestFarmingData {
 	selectedCrop?: string;
-	phaseLoadouts: Record<PestFarmingPhase, { armorSetId: string }>;
+	phaseLoadouts: Partial<Record<PestFarmingPhase, { armorSetId: string }>>;
 	sprayedPlot: boolean;
 	pesthunterAccessoryEnabled: boolean;
-	mantidPestKills: number;
 	timeOfDay: PestFarmingTimeOfDay;
 	attraction: PestAttractionSettings;
 	rateSettings: PestFarmingRateSettings;
@@ -87,14 +86,9 @@ const defaultData = {
 	infestedPlotProbability: 0.2,
 	zorroMode: ZorroMode.Normal,
 	pestFarming: {
-		phaseLoadouts: {
-			[PestFarmingPhase.Farm]: { armorSetId: PEST_MAIN_ARMOR_SET_ID },
-			[PestFarmingPhase.Spawn]: { armorSetId: PEST_SPAWN_ARMOR_SET_ID },
-			[PestFarmingPhase.Kill]: { armorSetId: PEST_MAIN_ARMOR_SET_ID },
-		},
+		phaseLoadouts: {},
 		sprayedPlot: true,
 		pesthunterAccessoryEnabled: true,
-		mantidPestKills: 0,
 		timeOfDay: 'day',
 		attraction: {
 			sprayonatorTarget: Pest.Slug,
@@ -120,33 +114,46 @@ const defaultData = {
 	},
 } as RatesData;
 
+function isLegacyDefaultPhaseLoadouts(loadouts?: Partial<PestFarmingData['phaseLoadouts']>): boolean {
+	return (
+		loadouts?.[PestFarmingPhase.Farm]?.armorSetId === PEST_MAIN_ARMOR_SET_ID &&
+		loadouts?.[PestFarmingPhase.Spawn]?.armorSetId === PEST_SPAWN_ARMOR_SET_ID &&
+		loadouts?.[PestFarmingPhase.Kill]?.armorSetId === PEST_MAIN_ARMOR_SET_ID
+	);
+}
+
+function normalizePestAttractionSettings(
+	data?: (Partial<PestAttractionSettings> & { selectedPest?: Pest }) | null
+): PestAttractionSettings {
+	const attraction = { ...(data ?? {}) };
+	delete attraction.selectedPest;
+	return {
+		...defaultData.pestFarming.attraction,
+		...attraction,
+		excludedPests: attraction.excludedPests ?? defaultData.pestFarming.attraction.excludedPests,
+	};
+}
+
 function normalizePestFarmingData(data?: Partial<PestFarmingData>): PestFarmingData {
 	const armorSetIds = new Set([PEST_MAIN_ARMOR_SET_ID, PEST_SPAWN_ARMOR_SET_ID]);
-	const normalizePhaseLoadout = (phase: PestFarmingPhase, fallbackArmorSetId: string): { armorSetId: string } => {
-		const loadout = data?.phaseLoadouts?.[phase];
-		const armorSetId =
-			loadout?.armorSetId && armorSetIds.has(loadout.armorSetId) ? loadout.armorSetId : fallbackArmorSetId;
-		return {
-			armorSetId,
-		};
-	};
+	const phaseLoadouts: PestFarmingData['phaseLoadouts'] = {};
+
+	if (!isLegacyDefaultPhaseLoadouts(data?.phaseLoadouts)) {
+		for (const phase of [PestFarmingPhase.Farm, PestFarmingPhase.Spawn, PestFarmingPhase.Kill]) {
+			const armorSetId = data?.phaseLoadouts?.[phase]?.armorSetId;
+			if (armorSetId && armorSetIds.has(armorSetId)) {
+				phaseLoadouts[phase] = { armorSetId };
+			}
+		}
+	}
 
 	return {
 		selectedCrop: data?.selectedCrop,
-		phaseLoadouts: {
-			[PestFarmingPhase.Farm]: normalizePhaseLoadout(PestFarmingPhase.Farm, PEST_MAIN_ARMOR_SET_ID),
-			[PestFarmingPhase.Spawn]: normalizePhaseLoadout(PestFarmingPhase.Spawn, PEST_SPAWN_ARMOR_SET_ID),
-			[PestFarmingPhase.Kill]: normalizePhaseLoadout(PestFarmingPhase.Kill, PEST_MAIN_ARMOR_SET_ID),
-		},
+		phaseLoadouts,
 		sprayedPlot: data?.sprayedPlot ?? defaultData.pestFarming.sprayedPlot,
 		pesthunterAccessoryEnabled: true,
-		mantidPestKills: 0,
 		timeOfDay: data?.timeOfDay ?? defaultData.pestFarming.timeOfDay,
-		attraction: {
-			...defaultData.pestFarming.attraction,
-			...(data?.attraction ?? {}),
-			excludedPests: data?.attraction?.excludedPests ?? defaultData.pestFarming.attraction.excludedPests,
-		},
+		attraction: normalizePestAttractionSettings(data?.attraction),
 		rateSettings: {
 			...defaultData.pestFarming.rateSettings,
 			...(data?.rateSettings ?? {}),

--- a/src/routes/(main)/@[id=id]/[[profile]]/pest-farming/pest-farming-context.svelte.ts
+++ b/src/routes/(main)/@[id=id]/[[profile]]/pest-farming/pest-farming-context.svelte.ts
@@ -19,7 +19,6 @@ import {
 	createPestFarmingPlayer,
 	Crop,
 	CROP_INFO,
-	CROP_TO_PEST,
 	DEFAULT_PEST_CYCLE_SETTINGS,
 	FarmingArmor,
 	FarmingEquipment,
@@ -167,11 +166,7 @@ export class PestFarmingPageContext {
 	pestVersion = $state(0);
 	selectedVacuumId = $state('');
 	armorSets = $state<PestArmorSetLoadout[]>([]);
-	phaseLoadouts = $state<Record<PestFarmingPhase, PestPhaseLoadout>>({
-		[PestFarmingPhase.Farm]: { armorSetId: PEST_MAIN_ARMOR_SET_ID },
-		[PestFarmingPhase.Spawn]: { armorSetId: PEST_SPAWN_ARMOR_SET_ID },
-		[PestFarmingPhase.Kill]: { armorSetId: PEST_MAIN_ARMOR_SET_ID },
-	});
+	phaseLoadouts = $state<Partial<Record<PestFarmingPhase, PestPhaseLoadout>>>({});
 	sharedEquipment = $state<Partial<Record<GearSlot, string>>>({});
 	activePhase = $state<PestFarmingPhase>(PestFarmingPhase.Farm);
 	itemsData = $state<RatesItemPriceData>({});
@@ -213,7 +208,6 @@ export class PestFarmingPageContext {
 
 		return {
 			...settings,
-			selectedPest: CROP_TO_PEST[this.selectedCropKey],
 			sprayonatorTarget: this.rates.pestFarming.sprayedPlot ? settings.sprayonatorTarget : undefined,
 			hooveriusVinylTarget: isHooverius ? settings.hooveriusVinylTarget : undefined,
 			hooveriusVinylMultiplier: isHooverius ? settings.hooveriusVinylMultiplier : undefined,
@@ -229,7 +223,7 @@ export class PestFarmingPageContext {
 		void this.itemsVersion;
 		return {
 			version: String(this.itemsVersion),
-			missingItemMode: 'zero',
+			missingItemMode: 'exclude',
 			items: {
 				...STATIC_NPC_ITEM_PRICES,
 				...Object.fromEntries(
@@ -242,15 +236,7 @@ export class PestFarmingPageContext {
 	});
 	pestRateCalculator = $derived.by(() => {
 		this.trackPestVersion();
-		return new PestFarmingRateCalculator({
-			player: this.pestPlayer,
-			options: {
-				crop: this.selectedCropKey,
-				cycle: this.pestRateSettings,
-				attraction: this.pestAttraction,
-			},
-			priceBook: this.pestRatePriceBook,
-		});
+		return this.#createRateCalculator();
 	});
 	pestRateResult = $derived.by(() => this.pestRateCalculator.calculate());
 	pestRateStateKey = $derived(this.pestRateResult.stateKey);
@@ -428,8 +414,30 @@ export class PestFarmingPageContext {
 	});
 
 	rateOutputItems = $derived.by(() => this.pestRateCalculator.getRequiredPriceItems(this.pestRateResult));
-	// eslint-disable-next-line svelte/prefer-svelte-reactivity
-	neededItems = $derived([...new Set([...getItemsFromUpgrades(this.neededItemUpgrades), ...this.rateOutputItems])]);
+	rateImpactItems = $derived.by(() => {
+		void this.itemsVersion;
+		this.trackPestVersion();
+		const calculator = this.#createRateCalculator();
+		const result = calculator.calculate();
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const items = new Set<string>();
+		for (const upgrade of this.neededItemUpgrades) {
+			const impact = this.#calculatePestRateImpact(calculator, result, this.activePhase, upgrade);
+			for (const itemId of impact.valuationDelta.missingItemIds) {
+				if (!this.itemsData[itemId]) items.add(itemId);
+			}
+		}
+		return [...items];
+	});
+
+	neededItems = $derived([
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		...new Set([
+			...getItemsFromUpgrades(this.neededItemUpgrades),
+			...this.rateOutputItems,
+			...this.rateImpactItems,
+		]),
+	]);
 	debouncedItems = new Debounced(() => this.neededItems, 1000);
 
 	constructor() {
@@ -441,12 +449,22 @@ export class PestFarmingPageContext {
 		$effect(() => this.#syncExternalState());
 		$effect(() => this.#syncSelectedCrop());
 		$effect(() => this.#syncVacuumSelection());
+		$effect(() => this.#syncDefaultSpawnArmorSelection());
 
 		onMount(() => this.#restoreSavedCrop());
 	}
 
 	refreshPestPlayer() {
-		this.pestPlayer = createPestFarmingPlayer(this.options);
+		let player = createPestFarmingPlayer(this.options);
+		const phaseLoadouts = this.#getRateSelectedDefaultPhaseLoadouts(player);
+		if (phaseLoadouts) {
+			this.options = {
+				...this.options,
+				phaseLoadouts,
+			} as PestFarmingPlayerOptions;
+			player = createPestFarmingPlayer(this.options);
+		}
+		this.pestPlayer = player;
 		this.#syncSessionSelectionsFromPestPlayer();
 		this.pestVersion++;
 	}
@@ -460,19 +478,16 @@ export class PestFarmingPageContext {
 		return `${this.ctx.uuid}:${this.ctx.selectedProfile?.profileId ?? ''}`;
 	}
 
-	#getPersistedPhaseLoadouts(): Record<PestFarmingPhase, PestPhaseLoadout> {
+	#getPersistedPhaseLoadouts(): Partial<Record<PestFarmingPhase, PestPhaseLoadout>> {
 		const loadouts = this.rates.pestFarming.phaseLoadouts;
-		return {
-			[PestFarmingPhase.Farm]: {
-				armorSetId: loadouts[PestFarmingPhase.Farm]?.armorSetId ?? PEST_MAIN_ARMOR_SET_ID,
-			},
-			[PestFarmingPhase.Spawn]: {
-				armorSetId: loadouts[PestFarmingPhase.Spawn]?.armorSetId ?? PEST_SPAWN_ARMOR_SET_ID,
-			},
-			[PestFarmingPhase.Kill]: {
-				armorSetId: loadouts[PestFarmingPhase.Kill]?.armorSetId ?? PEST_MAIN_ARMOR_SET_ID,
-			},
-		};
+		return Object.fromEntries(
+			[PestFarmingPhase.Farm, PestFarmingPhase.Spawn, PestFarmingPhase.Kill]
+				.map((phase) => {
+					const armorSetId = loadouts[phase]?.armorSetId;
+					return armorSetId ? [phase, { armorSetId }] : undefined;
+				})
+				.filter((entry): entry is [PestFarmingPhase, PestPhaseLoadout] => entry !== undefined)
+		);
 	}
 
 	#getPersistablePhaseLoadouts(
@@ -502,6 +517,50 @@ export class PestFarmingPageContext {
 		) as Record<PestFarmingPhase, PestPhaseLoadout>;
 		this.sharedEquipment = { ...this.pestPlayer.sharedEquipment };
 		this.selectedVacuumId = this.pestPlayer.selectedVacuum?.item.uuid ?? this.selectedVacuumId;
+	}
+
+	#syncDefaultSpawnArmorSelection(): void {
+		void this.pestRatePriceBook.version;
+		if (this.rates.pestFarming.phaseLoadouts[PestFarmingPhase.Spawn]?.armorSetId) return;
+
+		const phaseLoadouts = this.#getRateSelectedDefaultPhaseLoadouts(this.pestPlayer);
+		if (!phaseLoadouts) return;
+
+		this.options = {
+			...this.options,
+			phaseLoadouts,
+		} as PestFarmingPlayerOptions;
+		untrack(() => this.refreshPestPlayer());
+	}
+
+	#getRateSelectedDefaultPhaseLoadouts(
+		player: PestFarmingPlayer
+	): Record<PestFarmingPhase, PestPhaseLoadout> | undefined {
+		const candidates = this.#getDefaultSpawnArmorCandidateIds(player);
+		if (!candidates) return;
+
+		const bestId = this.#createRateCalculator(player).getBestSpawnPhaseArmorSetId(candidates);
+		if (!bestId || player.phaseLoadouts[PestFarmingPhase.Spawn]?.armorSetId === bestId) return;
+
+		return {
+			...player.phaseLoadouts,
+			[PestFarmingPhase.Spawn]: {
+				...player.phaseLoadouts[PestFarmingPhase.Spawn],
+				armorSetId: bestId,
+			},
+		};
+	}
+
+	#getDefaultSpawnArmorCandidateIds(player: PestFarmingPlayer): readonly string[] | undefined {
+		if (this.rates.pestFarming.phaseLoadouts[PestFarmingPhase.Spawn]?.armorSetId) return undefined;
+
+		const mainId =
+			player.armorSetLoadouts.find((set) => set.id === PEST_MAIN_ARMOR_SET_ID)?.id ??
+			player.armorSetLoadouts[0]?.id;
+		const spawnId = player.armorSetLoadouts.find((set) => set.id === PEST_SPAWN_ARMOR_SET_ID)?.id;
+		if (!mainId || !spawnId || mainId === spawnId) return undefined;
+
+		return [mainId, spawnId];
 	}
 
 	trackPestVersion(): number {
@@ -760,10 +819,11 @@ export class PestFarmingPageContext {
 
 	selectPhaseArmorSet(phase: PestFarmingPhase, armorSetId: string): void {
 		if (!this.pestPlayer.setPhaseArmorSet(phase, armorSetId)) return;
+		const baseLoadouts = this.pestPlayer.phaseLoadouts;
 		const phaseLoadouts = {
-			...this.phaseLoadouts,
+			...baseLoadouts,
 			[phase]: {
-				...this.phaseLoadouts[phase],
+				...baseLoadouts[phase],
 				armorSetId,
 			},
 		};
@@ -776,10 +836,11 @@ export class PestFarmingPageContext {
 
 	selectPhasePet(phase: PestFarmingPhase, petId: string): void {
 		if (!this.pestPlayer.setPhasePet(phase, petId)) return;
+		const baseLoadouts = this.pestPlayer.phaseLoadouts;
 		const phaseLoadouts = {
-			...this.phaseLoadouts,
+			...baseLoadouts,
 			[phase]: {
-				...this.phaseLoadouts[phase],
+				...baseLoadouts[phase],
 				petId,
 			},
 		};
@@ -790,13 +851,23 @@ export class PestFarmingPageContext {
 	}
 
 	getPestRateImpact(upgrade: FortuneUpgrade): PestFarmingUpgradeRateImpact | undefined {
-		const result = this.pestRateResult;
-		const key = `${this.pestRateStateKey}:${this.activePhase}:${getUpgradeIdentity(upgrade)}`;
+		const calculator = this.#createRateCalculator();
+		const result = calculator.calculate();
+		return this.#calculatePestRateImpact(calculator, result, this.activePhase, upgrade);
+	}
+
+	#calculatePestRateImpact(
+		calculator: PestFarmingRateCalculator,
+		result: ReturnType<PestFarmingRateCalculator['calculate']>,
+		phase: PestFarmingPhase,
+		upgrade: FortuneUpgrade
+	): PestFarmingUpgradeRateImpact {
+		const key = `${result.stateKey}:${phase}:${getUpgradeIdentity(upgrade)}`;
 		const cached = this.#rateImpactMemo.get(key);
 		if (cached) return cached;
 
-		const impact = this.pestRateCalculator.calculateUpgradeImpact({
-			phase: this.activePhase,
+		const impact = calculator.calculateUpgradeImpact({
+			phase,
 			upgrade,
 			before: result,
 		});
@@ -822,9 +893,23 @@ export class PestFarmingPageContext {
 		} as PestFarmingPlayerOptions);
 	}
 
+	#createRateCalculator(player = this.pestPlayer): PestFarmingRateCalculator {
+		const spawnArmorSetIds = this.#getDefaultSpawnArmorCandidateIds(player);
+		return new PestFarmingRateCalculator({
+			player,
+			options: {
+				crop: this.selectedCropKey,
+				cycle: this.pestRateSettings,
+				attraction: this.pestAttraction,
+			},
+			priceBook: this.pestRatePriceBook,
+			armorSelection: spawnArmorSetIds ? { spawnArmorSetIds } : undefined,
+		});
+	}
+
 	#getRateDeltaForPlayer(player: PestFarmingPlayer): number {
 		const before = this.pestRateResult.valuation.coinsPerHour;
-		const after = this.pestRateCalculator.withPlayer(player).calculate().valuation.coinsPerHour;
+		const after = this.#createRateCalculator(player).calculate().valuation.coinsPerHour;
 		const delta = after - before;
 		return Number.isFinite(delta) ? delta : 0;
 	}
@@ -903,7 +988,7 @@ export class PestFarmingPageContext {
 			pets: this.pets,
 			selectedVacuumId,
 			armorSets,
-			phaseLoadouts,
+			phaseLoadouts: Object.keys(phaseLoadouts).length > 0 ? phaseLoadouts : undefined,
 			sharedEquipment,
 			selectedCrop: this.selectedCropKey,
 
@@ -946,7 +1031,6 @@ export class PestFarmingPageContext {
 			wrigglingLarva: Number(this.ctx.member.current?.unparsed?.consumed?.wriggling_larva ?? 0),
 			sprayedPlot: rates.pestFarming.sprayedPlot,
 			pesthunterAccessoryEnabled: true,
-			mantidPestKills: 0,
 			infestedPlotProbability: rates.infestedPlotProbability,
 			cocoaFortuneUpgrade: this.ctx.member.current?.chocolateFactory?.cocoaFortuneUpgrades,
 			temporaryFortune: rates.useTemp ? rates.temp : undefined,


### PR DESCRIPTION
- Removed erroneous extra weighting on the pest associated with the selected crop
- Prefer reusing your farm armor for the spawn phase if it's better
- Adds full mantid support
- Fixes some visual regressions on the fortune page