### PR TITLE
Add decimal support for Numeric inputs in pest farming settings

### DIFF
--- a/src/components/ui/number-input/number-input.svelte
+++ b/src/components/ui/number-input/number-input.svelte
@@ -6,6 +6,7 @@
 	interface Props extends HTMLInputAttributes {
 		class?: string;
 		value?: number;
+		inputmode?: 'numeric' | 'decimal';
 		onValueChange?: (value: number | undefined) => void;
 	}
 
@@ -13,6 +14,7 @@
 		class: className = undefined,
 		value = $bindable(undefined),
 		onValueChange = undefined,
+		inputmode = 'numeric',
 		...rest
 	}: Props = $props();
 
@@ -30,6 +32,11 @@
 
 				if (isNaN(+v)) {
 					value = previousN;
+					return;
+				}
+
+				// Allow users to type a trailing decimal point
+				if (inputmode !== 'numeric' && String(v).endsWith('.')) {
 					return;
 				}
 
@@ -62,7 +69,7 @@
 	)}
 	bind:value
 	type="text"
-	inputmode="numeric"
+	{inputmode}
 	use:validator={value}
 	{...rest}
 />

--- a/src/routes/(main)/@[id=id]/[[profile]]/pest-farming/pest-settings.svelte
+++ b/src/routes/(main)/@[id=id]/[[profile]]/pest-farming/pest-settings.svelte
@@ -215,9 +215,10 @@
 		<NumberInput
 			class="my-1 h-10 max-w-32"
 			value={pest.pestRateSettings.blocksPerSecond}
+			inputmode="decimal"
 			onValueChange={(value) => pest.setPestRateSetting('blocksPerSecond', value ?? 0)}
 			min={0}
-			max={80}
+			max={20}
 		/>
 	</SettingListItem>
 	<SettingSeperator />
@@ -229,9 +230,10 @@
 		<NumberInput
 			class="my-1 h-10 max-w-32"
 			value={pest.pestRateSettings.spawnBlocksPerSecond}
+			inputmode="decimal"
 			onValueChange={(value) => pest.setPestRateSetting('spawnBlocksPerSecond', value ?? 0)}
 			min={0}
-			max={80}
+			max={20}
 		/>
 	</SettingListItem>
 	<SettingSeperator />
@@ -243,6 +245,7 @@
 		<NumberInput
 			class="my-1 h-10 max-w-32"
 			value={pest.pestRateSettings.farmSwapBeforeCooldownSeconds}
+			inputmode="decimal"
 			onValueChange={(value) => pest.setPestRateSetting('farmSwapBeforeCooldownSeconds', value ?? 0)}
 			min={0}
 			max={120}
@@ -254,6 +257,7 @@
 		<NumberInput
 			class="my-1 h-10 max-w-32"
 			value={pest.pestRateSettings.farmToSpawnSwapSeconds}
+			inputmode="decimal"
 			onValueChange={(value) => pest.setPestRateSetting('farmToSpawnSwapSeconds', value ?? 0)}
 			min={0}
 			max={60}
@@ -265,6 +269,7 @@
 		<NumberInput
 			class="my-1 h-10 max-w-32"
 			value={pest.pestRateSettings.spawnToKillSwapSeconds}
+			inputmode="decimal"
 			onValueChange={(value) => pest.setPestRateSetting('spawnToKillSwapSeconds', value ?? 0)}
 			min={0}
 			max={60}
@@ -276,6 +281,7 @@
 		<NumberInput
 			class="my-1 h-10 max-w-32"
 			value={pest.pestRateSettings.fixedKillSetupSeconds}
+			inputmode="decimal"
 			onValueChange={(value) => pest.setPestRateSetting('fixedKillSetupSeconds', value ?? 0)}
 			min={0}
 			max={120}
@@ -287,6 +293,7 @@
 		<NumberInput
 			class="my-1 h-10 max-w-32"
 			value={pest.pestRateSettings.fixedPestSearchSeconds}
+			inputmode="decimal"
 			onValueChange={(value) => pest.setPestRateSetting('fixedPestSearchSeconds', value ?? 0)}
 			min={0}
 			max={300}
@@ -298,6 +305,7 @@
 		<NumberInput
 			class="my-1 h-10 max-w-32"
 			value={pest.pestRateSettings.secondsPerPestKill}
+			inputmode="decimal"
 			onValueChange={(value) => pest.setPestRateSetting('secondsPerPestKill', value ?? 0)}
 			min={0}
 			max={60}
@@ -309,6 +317,7 @@
 		<NumberInput
 			class="my-1 h-10 max-w-32"
 			value={pest.pestRateSettings.returnToFarmSeconds}
+			inputmode="decimal"
 			onValueChange={(value) => pest.setPestRateSetting('returnToFarmSeconds', value ?? 0)}
 			min={0}
 			max={120}


### PR DESCRIPTION
Improvements to Pest Farming by adding capability to define decimal values for things like BPS and other non counting values.

**Changes:**
 - Update Numeric input field to allow for decimal/float values (default still remains numeric)
 - Adjust Max values for BPS to 20 (Maximum BPS value capable in game)

<img width="817" height="367" alt="image" src="https://github.com/user-attachments/assets/5656ea05-b3f4-4e5b-8f48-a0754b9815fe" />
