### PR TITLE
Fix/wrong enchant fortune calculation

### DIFF
--- a/packages/farming-weight/src/fortune/farmingtool.test.ts
+++ b/packages/farming-weight/src/fortune/farmingtool.test.ts
@@ -388,7 +388,6 @@ test('FarmingTool getStats returns multiple stats', () => {
 	expect(dicerStats[Stat.FarmingWisdom]).toBeDefined();
 });
 
-
 const eclipseSickle = {
 	id: 293,
 	count: 1,
@@ -459,7 +458,7 @@ test('Harvesting enchant should be counted once on multiple crop tools', () => {
 	// ensure advanced gardening hoe has 9 specific crops (universal tool)
 	expect(tool.crops).toHaveLength(9);
 
-    // harvesting 6 is generic, should only be applied once no matter the number of crops
+	// harvesting 6 is generic, should only be applied once no matter the number of crops
 	expect(tool.fortuneBreakdown['Base Stats']).toBe(15);
 	expect(tool.fortuneBreakdown.Harvesting).toBe(75);
 	expect(tool.fortune).toBe(90);

--- a/packages/farming-weight/src/fortune/farmingtool.test.ts
+++ b/packages/farming-weight/src/fortune/farmingtool.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { Crop } from '../constants/crops.js';
 import { ReforgeTarget } from '../constants/reforges.js';
 import { Stat } from '../constants/stats.js';
 import { TOOL_EXP_LEVELS } from '../constants/toollevels.js';
@@ -385,4 +386,85 @@ test('FarmingTool getStats returns multiple stats', () => {
 	expect(dicerStats[Stat.FarmingFortune]).toBeDefined();
 	expect(dicerStats[Stat.Speed]).toBeDefined();
 	expect(dicerStats[Stat.FarmingWisdom]).toBeDefined();
+});
+
+
+const eclipseSickle = {
+	id: 293,
+	count: 1,
+	skyblockId: 'THEORETICAL_HOE_SUNFLOWER_3',
+	uuid: '7c1de0a4-9f52-4a3b-8d16-2ec4b0f9a731',
+	name: '§dEclipse Sickle Mk. III',
+	lore: [],
+	enchantments: {
+		harvesting: 6,
+	},
+	attributes: {
+		levelable_lvl: '1',
+		levelable_overclocks: '0',
+		levelable_exp: '0',
+	},
+	gems: {},
+};
+
+test('Harvesting enchant should be counted once on multiple crop tools', () => {
+	const tool = new FarmingTool(eclipseSickle);
+
+	// ensure eclipse has 2 specific crops
+	expect(tool.crops).toHaveLength(2);
+
+	// harvesting 6 is generic, should only be applied once no matter the number of crops
+	expect(tool.fortuneBreakdown.Harvesting).toBe(75);
+	expect(tool.getStat(Stat.FarmingFortune)).toBe(75);
+
+	// breakdown should match total sum
+	const breakdownTotal = Object.values(tool.fortuneBreakdown).reduce((a, b) => a + b, 0);
+	expect(tool.fortune).toBe(breakdownTotal);
+});
+
+test('Only enchants tied to the selected crop should apply on multiple crop tools', () => {
+	const withTurbo = {
+		...eclipseSickle,
+		enchantments: { harvesting: 6, turbo_sunflower: 5 },
+	};
+
+	// turbo sunflower is tied to sunflower, shouldn't apply when moonflower is selected
+	const farmingMoonflower = new FarmingTool(withTurbo, { selectedCrop: Crop.Moonflower });
+	expect(farmingMoonflower.fortuneBreakdown['Turbo-Sunflower']).toBeUndefined();
+	expect(farmingMoonflower.fortune).toBe(79);
+
+	// turbo sunflower should apply when sunflower is selected
+	const farmingSunflower = new FarmingTool(withTurbo, { selectedCrop: Crop.Sunflower });
+	expect(farmingSunflower.fortuneBreakdown['Turbo-Sunflower']).toBe(25);
+	expect(farmingSunflower.fortune).toBe(104);
+});
+
+const advancedGardeningHoe = {
+	id: 293,
+	count: 1,
+	skyblockId: 'ADVANCED_GARDENING_HOE',
+	uuid: 'f3b7c210-5d84-4e69-9a0c-1b8e7d4a6f52',
+	name: '§9Advanced Gardening Hoe',
+	lore: [],
+	enchantments: {
+		harvesting: 6,
+	},
+	attributes: {},
+	gems: {},
+};
+
+test('Harvesting enchant should be counted once on multiple crop tools', () => {
+	const tool = new FarmingTool(advancedGardeningHoe);
+
+	// ensure advanced gardening hoe has 9 specific crops (universal tool)
+	expect(tool.crops).toHaveLength(9);
+
+    // harvesting 6 is generic, should only be applied once no matter the number of crops
+	expect(tool.fortuneBreakdown['Base Stats']).toBe(15);
+	expect(tool.fortuneBreakdown.Harvesting).toBe(75);
+	expect(tool.fortune).toBe(90);
+	expect(tool.getStat(Stat.FarmingFortune)).toBe(90);
+
+	const breakdownTotal = Object.values(tool.fortuneBreakdown).reduce((a, b) => a + b, 0);
+	expect(tool.fortune).toBe(breakdownTotal);
 });

--- a/packages/farming-weight/src/fortune/farmingtool.ts
+++ b/packages/farming-weight/src/fortune/farmingtool.ts
@@ -1,14 +1,14 @@
-import { CROP_INFO, type Crop } from '../constants/crops.js';
+import { type Crop, CROP_INFO } from '../constants/crops.js';
 import { FARMING_ENCHANTS } from '../constants/enchants.js';
-import { type Rarity, REFORGES, type Reforge, ReforgeTarget, type ReforgeTier } from '../constants/reforges.js';
+import { type Rarity, type Reforge, REFORGES, ReforgeTarget, type ReforgeTier } from '../constants/reforges.js';
 import { Stat } from '../constants/stats.js';
 import { TOOL_EXP_LEVELS } from '../constants/toollevels.js';
 import {
-	type FortuneSourceProgress,
-	type FortuneUpgrade,
-	getQueryStats,
-	includesFortuneSourceType,
-	type StatQueryOptions,
+    type FortuneSourceProgress,
+    type FortuneUpgrade,
+    getQueryStats,
+    includesFortuneSourceType,
+    type StatQueryOptions,
 } from '../constants/upgrades.js';
 import type { Effect, EffectEnvironment } from '../effects/types.js';
 import { statsToEffects } from '../items/sources/effects-util.js';
@@ -404,13 +404,13 @@ export class FarmingTool extends UpgradeableBase {
 			sum += peridot;
 		}
 
-		// Enchantments
+		// Enchantments 
 		const enchantments = Object.entries(this.item.enchantments ?? {});
 		for (const [enchant, level] of enchantments) {
 			if (!level) continue;
 
 			const enchantment = FARMING_ENCHANTS[enchant];
-			if (!enchantment || !level) continue;
+			if (!enchantment) continue;
 			if (enchantment.cropSpecific && !this.crops.includes(enchantment.cropSpecific)) continue;
 
 			for (const crop of this.crops) {
@@ -422,7 +422,7 @@ export class FarmingTool extends UpgradeableBase {
 				}
 
 				if (fortune > 0) {
-					this.fortuneBreakdown[enchantment.name] = fortune;
+					this.fortuneBreakdown[enchantment.name] = (this.fortuneBreakdown[enchantment.name] ?? 0) + fortune;
 					sum += fortune;
 				}
 			}

--- a/packages/farming-weight/src/fortune/farmingtool.ts
+++ b/packages/farming-weight/src/fortune/farmingtool.ts
@@ -299,15 +299,11 @@ export class FarmingTool extends UpgradeableBase {
 			if (!level) continue;
 
 			const enchantment = FARMING_ENCHANTS[enchant];
-			if (!enchantment || !level) continue;
-			if (enchantment.cropSpecific && !this.crops.includes(enchantment.cropSpecific)) continue;
+			if (!enchantment) continue;
+			if (enchantment.cropSpecific && !crops.includes(enchantment.cropSpecific)) continue;
 
-			const enchantCrops = crops.length > 0 ? crops : [undefined];
-			for (const crop of enchantCrops) {
-				const val = getStatFromEnchant(level, enchantment, stat, this.options, crop);
-
-				sum += val;
-			}
+			const crop = enchantment.cropSpecific ?? crops[0];
+			sum += getStatFromEnchant(level, enchantment, stat, this.options, crop);
 		}
 
 		return sum;
@@ -404,27 +400,32 @@ export class FarmingTool extends UpgradeableBase {
 			sum += peridot;
 		}
 
-		// Enchantments 
+		// Enchantments
+		// Only the crop actually selected is taken into account (tools with multiples crops)
+		const selected = this.options?.selectedCrop;
+		const activeCrops = selected && this.crops.includes(selected) ? [selected] : this.crops;
+
 		const enchantments = Object.entries(this.item.enchantments ?? {});
 		for (const [enchant, level] of enchantments) {
 			if (!level) continue;
 
 			const enchantment = FARMING_ENCHANTS[enchant];
 			if (!enchantment) continue;
-			if (enchantment.cropSpecific && !this.crops.includes(enchantment.cropSpecific)) continue;
+			if (enchantment.cropSpecific && !activeCrops.includes(enchantment.cropSpecific)) continue;
 
-			for (const crop of this.crops) {
-				let fortune = getFortuneFromEnchant(level, enchantment, this.options, crop);
-				const cropStat = CROP_INFO[crop]?.fortuneType;
+			// Evaluate once : general enchant has single flat value, crop-specific already linked to his own crop
+			const crop = enchantment.cropSpecific ?? activeCrops[0];
 
-				if (cropStat) {
-					fortune += getStatFromEnchant(level, enchantment, cropStat, this.options, crop);
-				}
+			let fortune = getFortuneFromEnchant(level, enchantment, this.options, crop);
 
-				if (fortune > 0) {
-					this.fortuneBreakdown[enchantment.name] = (this.fortuneBreakdown[enchantment.name] ?? 0) + fortune;
-					sum += fortune;
-				}
+			const cropStat = crop ? CROP_INFO[crop]?.fortuneType : undefined;
+			if (cropStat) {
+				fortune += getStatFromEnchant(level, enchantment, cropStat, this.options, crop);
+			}
+
+			if (fortune > 0) {
+				this.fortuneBreakdown[enchantment.name] = (this.fortuneBreakdown[enchantment.name] ?? 0) + fortune;
+				sum += fortune;
 			}
 		}
 

--- a/packages/farming-weight/src/fortune/farmingtool.ts
+++ b/packages/farming-weight/src/fortune/farmingtool.ts
@@ -1,14 +1,14 @@
-import { type Crop, CROP_INFO } from '../constants/crops.js';
+import { CROP_INFO, type Crop } from '../constants/crops.js';
 import { FARMING_ENCHANTS } from '../constants/enchants.js';
-import { type Rarity, type Reforge, REFORGES, ReforgeTarget, type ReforgeTier } from '../constants/reforges.js';
+import { type Rarity, REFORGES, type Reforge, ReforgeTarget, type ReforgeTier } from '../constants/reforges.js';
 import { Stat } from '../constants/stats.js';
 import { TOOL_EXP_LEVELS } from '../constants/toollevels.js';
 import {
-    type FortuneSourceProgress,
-    type FortuneUpgrade,
-    getQueryStats,
-    includesFortuneSourceType,
-    type StatQueryOptions,
+	type FortuneSourceProgress,
+	type FortuneUpgrade,
+	getQueryStats,
+	includesFortuneSourceType,
+	type StatQueryOptions,
 } from '../constants/upgrades.js';
 import type { Effect, EffectEnvironment } from '../effects/types.js';
 import { statsToEffects } from '../items/sources/effects-util.js';


### PR DESCRIPTION
Found out that the Eclipse Hoe fortune calculation was wrong :
<img width="400" alt="before" src="https://github.com/user-attachments/assets/4e1cff99-9e9a-4b7e-9f40-b10d67f7053e" />

> The fortune total was wrong, and the breakdown was in fact right, but adding all the numbers wasn't leading to the total.


I first fixed the breakdown calculation for debugging purposes, which showed that generic enchants were applied for each crop.
<img width="400" alt="breakdown" src="https://github.com/user-attachments/assets/038ab170-c1c6-497a-ad64-a7a3b75a4eb5" />
> In my example case, we can see that `Harvesting`, `Dedication` & `Cultivating` were applied twice, once for each specific crop. Furthermore, when `Sunflower` is selected, we add `Turbo-Moonflower` fortune to the total.
 
To fix that, I modified the `farmingtool.ts` file to take all generic enchants into account only once.
In addition, now only the selected crop's enchants apply (`Turbo` enchants)
> For example, when `Moonflower` is selected, `Turbo-Sunflower` fortune is no longer added to the total.
<img width="400" alt="fixed" src="https://github.com/user-attachments/assets/e34f83c7-ed3a-40a3-a333-55f0646e79af" />
Finally, I updated the test to verify that the behaviour was correctly implemented, and to prevent future updates from breaking it...